### PR TITLE
Add sample size-based ML/REML estimators

### DIFF
--- a/pymare/core.py
+++ b/pymare/core.py
@@ -6,7 +6,9 @@ import numpy as np
 import pandas as pd
 
 from .estimators import (WeightedLeastSquares, DerSimonianLaird,
-                         LikelihoodBased, StanMetaRegression)
+                         VarianceBasedLikelihoodEstimator,
+                         SampleSizeBasedLikelihoodEstimator,
+                         StanMetaRegression)
 from .stats import ensure_2d
 
 
@@ -123,8 +125,8 @@ def meta_regression(estimates, variances=None, predictors=None,
     method = method.lower()
 
     estimator_cls = {
-        'ml': partial(LikelihoodBased, method=method),
-        'reml': partial(LikelihoodBased, method=method),
+        'ml': partial(VarianceBasedLikelihoodEstimator, method=method),
+        'reml': partial(VarianceBasedLikelihoodEstimator, method=method),
         'dl': DerSimonianLaird,
         'wls': WeightedLeastSquares,
         'fe': WeightedLeastSquares,

--- a/pymare/core.py
+++ b/pymare/core.py
@@ -42,7 +42,9 @@ class Dataset:
         # Provide convenient access to stored kwargs.
         if key in self.kwargs:
             return self.kwargs[key]
-        raise AttributeError
+        raise AttributeError("{} object has no attribute {}".format(
+                                self.__class__.__name__, key))
+
 
     def _get_predictors(self, X, names, add_intercept):
         if X is None and not add_intercept:

--- a/pymare/estimators/__init__.py
+++ b/pymare/estimators/__init__.py
@@ -1,9 +1,12 @@
 from .estimators import (WeightedLeastSquares, DerSimonianLaird,
-                         LikelihoodBased, StanMetaRegression)
+                         VarianceBasedLikelihoodEstimator,
+                         SampleSizeBasedLikelihoodEstimator,
+                         StanMetaRegression)
 
 __all__ = [
     'WeightedLeastSquares',
     'DerSimonianLaird',
-    'LikelihoodBased',
+    'VarianceBasedLikelihoodEstimator',
+    'SampleSizeBasedLikelihoodEstimator',
     'StanMetaRegression'
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,14 @@ def dataset(variables):
 
 
 @pytest.fixture(scope='package')
+def dataset_n():
+    y = np.array([[-3., -0.5, 0., -5.01, 0.35, -2., -6., -4., -4.3, -0.1, -1.]]).T
+    n = np.array([[16, 16, 20.548, 32.597, 14., 11.118, 4.444, 12.414, 26.963,
+                   130.556, 126.76]]).T / 2
+    return Dataset(y, sample_sizes=n)
+
+
+@pytest.fixture(scope='package')
 def vars_with_intercept():
     y = np.array([[-1, 0.5, 0.5, 0.5, 1, 1, 2, 10]]).T
     v = np.array([[1, 1, 2.4, 0.5, 1, 1, 1.2, 1.5]]).T

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from pymare.estimators import (WeightedLeastSquares, DerSimonianLaird,
                                VarianceBasedLikelihoodEstimator,
+                               SampleSizeBasedLikelihoodEstimator,
                                StanMetaRegression)
 
 
@@ -27,7 +28,7 @@ def test_dersimonian_laird_estimator(dataset):
     assert np.allclose(tau2, 8.3627, atol=1e-4)
 
 
-def test_maximum_likelihood_estimator(dataset):
+def test_variance_based_maximum_likelihood_estimator(dataset):
     # ground truth values are from metafor package in R
     results = VarianceBasedLikelihoodEstimator(method='ML').fit(dataset)
     beta, tau2 = results['beta']['est'], results['tau2']['est']
@@ -35,12 +36,34 @@ def test_maximum_likelihood_estimator(dataset):
     assert np.allclose(tau2, 7.7649, atol=1e-4)
 
 
-def test_restricted_maximum_likelihood_estimator(dataset):
+def test_variance_based_restricted_maximum_likelihood_estimator(dataset):
     # ground truth values are from metafor package in R
     results = VarianceBasedLikelihoodEstimator(method='REML').fit(dataset)
     beta, tau2 = results['beta']['est'], results['tau2']['est']
     assert np.allclose(beta, [-0.1066, 0.7700], atol=1e-4)
     assert np.allclose(tau2, 10.9499, atol=1e-4)
+
+
+def test_sample_size_based_maximum_likelihood_estimator(dataset_n):
+    # ground truth values are from metafor package in R
+    results = SampleSizeBasedLikelihoodEstimator(method='ML').fit(dataset_n)
+    beta = results['beta']['est']
+    sigma2 = results['sigma2']['est']
+    tau2 = results['tau2']['est']
+    assert np.allclose(beta, [-2.0951], atol=1e-4)
+    assert np.allclose(sigma2, 12.777, atol=1e-4)
+    assert np.allclose(tau2, 2.8268, atol=1e-4)
+
+
+def test_sample_size_based_restricted_maximum_likelihood_estimator(dataset_n):
+    # ground truth values are from metafor package in R
+    results = SampleSizeBasedLikelihoodEstimator(method='REML').fit(dataset_n)
+    beta = results['beta']['est']
+    sigma2 = results['sigma2']['est']
+    tau2 = results['tau2']['est']
+    assert np.allclose(beta, [-2.1071], atol=1e-4)
+    assert np.allclose(sigma2, 13.048, atol=1e-4)
+    assert np.allclose(tau2, 3.2177, atol=1e-4)
 
 
 def test_stan_estimator(dataset):

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -1,7 +1,8 @@
 import numpy as np
 
 from pymare.estimators import (WeightedLeastSquares, DerSimonianLaird,
-                               LikelihoodBased, StanMetaRegression)
+                               VarianceBasedLikelihoodEstimator,
+                               StanMetaRegression)
 
 
 def test_weighted_least_squares_estimator(dataset):
@@ -28,7 +29,7 @@ def test_dersimonian_laird_estimator(dataset):
 
 def test_maximum_likelihood_estimator(dataset):
     # ground truth values are from metafor package in R
-    results = LikelihoodBased(method='ML').fit(dataset)
+    results = VarianceBasedLikelihoodEstimator(method='ML').fit(dataset)
     beta, tau2 = results['beta']['est'], results['tau2']['est']
     assert np.allclose(beta, [-0.1072, 0.7653], atol=1e-4)
     assert np.allclose(tau2, 7.7649, atol=1e-4)
@@ -36,7 +37,7 @@ def test_maximum_likelihood_estimator(dataset):
 
 def test_restricted_maximum_likelihood_estimator(dataset):
     # ground truth values are from metafor package in R
-    results = LikelihoodBased(method='REML').fit(dataset)
+    results = VarianceBasedLikelihoodEstimator(method='REML').fit(dataset)
     beta, tau2 = results['beta']['est'], results['tau2']['est']
     assert np.allclose(beta, [-0.1066, 0.7700], atol=1e-4)
     assert np.allclose(tau2, 10.9499, atol=1e-4)


### PR DESCRIPTION
Adds a new `SampleSizeBasedLikelihoodEstimator` class that produces maximum-likelihood random-effects estimates for datasets that have estimates and sample sizes but no variances. This is maybe the modal situation with fMRI data, so it's a nice thing to have.

The approach is based on a simple idea in [this paper](https://www.ncbi.nlm.nih.gov/pubmed/28681700) (though I'm sure it's been suggested before in other places), which is to replace the standard log-likelihood function for the random-effects model with an analogous LL based not only beta and tau^2, but also a sigma^2 parameter that's scaled by the (known) inverse sample size. I.e., instead of study estimates being distributed with a variance of `tau^2 + v` (where `v` is the vector of observed sampling variances for the available studies), we assume they're distributed with a variance of `tau^2 + sigma^2/n` (where `n` is the vector of known sample sizes, and `sigma^2` is an additional parameter estimated from the data).

I haven't done any systematic investigation of the performance of this estimator, but the above paper suggests it works reasonably well in many cases, and if nothing else this seems like an improvement over just fitting a GLM to the estimates directly (i.e., ignoring sampling variance/sample size entirely).