### PR TITLE
Fix Optimiser

### DIFF
--- a/pymare/stats.py
+++ b/pymare/stats.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import scipy.stats as ss
-from scipy.optimize import root
+from scipy.optimize import minimize
 
 
 def ensure_2d(arr):
@@ -46,8 +46,8 @@ def q_profile(y, v, X, alpha=0.05):
     l_crit = ss.chi2.ppf(1 - alpha / 2, df)
     u_crit = ss.chi2.ppf(alpha / 2, df)
     args = (ensure_2d(y), ensure_2d(v), X)
-    lb = root(lambda x: (q_gen(*args, x) - l_crit)**2, 0).x[0]
-    ub = root(lambda x: (q_gen(*args, x) - u_crit)**2, 100).x[0]
+    lb = minimize(lambda x: (q_gen(*args, x) - l_crit)**2, 0,   bounds=[(0,None)]).x[0]
+    ub = minimize(lambda x: (q_gen(*args, x) - u_crit)**2, 100, bounds=[(0,None)]).x[0]
     return {'ci_l': lb, 'ci_u': ub}
 
 


### PR DESCRIPTION
Wrong optimiser was used... replaced `root` which is used for finding _roots_ of functions, i.e. zero crossings, with `minimize`, appropriate since the cost function for finding CI's was the squared difference from target level.

What's more, `minimize` allows the use of bounds.

HOWEVER, all of this was for naught, since once I fixed this problem with the CI optimiser, finally getting to the point of calling something like 
```
mod=meta_regression(estimates=y,predictors=X,sample_sizes=n,method='ML')
```
which will trigger use of `SampleSizeBasedLikelihoodEstimator`, I then ran into this error:
```
/anaconda3/envs/py3/lib/python3.7/site-packages/pymare/results.py in compute_beta_stats()
     76         def compute_beta_stats():
     77             v, X, alpha = self.dataset.variances, self.dataset.predictors, self.alpha
---> 78             w = 1. / (v + self['tau2']['est'])
     79             estimate = self['beta']['est']
     80             se = np.sqrt(np.diag(np.linalg.pinv((X * w).T.dot(X))))

TypeError: unsupported operand type(s) for +: 'NoneType' and 'float'
```

This happens because, of course for this setting, `self.dataset.variances` is empty.  What has to happen, of course, is that once `SampleSizeBasedLikelihoodEstimator` is called the first time the value of `sigma` has to make its way (from scalar into a vector) to the `self.dataset.variances` variable.  This is beyond my scope/skills.

As a MINOR thing, I couldn't figure out how to use the Bounds object in `stats.py` with `minimize`, which is what we need since we should be setting `keep_feasible=True`, different from it's default of `False`.  I tried:
```
    Bds = Bounds(0,None,keep_feasible=True)
    lb = minimize(lambda x: (q_gen(*args, x) - l_crit)**2, 0,   bounds=Bds).x[0]
    ub = minimize(lambda x: (q_gen(*args, x) - u_crit)**2, 100, bounds=Bds).x[0]
```
but kept getting errors of `IndexError: tuple index out of range` or other strangeness.