### PR TITLE
Fixes to SampleSizeBasedLikelihoodEstimator

### DIFF
--- a/pymare/estimators/estimators.py
+++ b/pymare/estimators/estimators.py
@@ -242,8 +242,8 @@ class SampleSizeBasedLikelihoodEstimator(BaseEstimator):
         # set tau^2 to 0 and compute starting values
         tau2 = 0.
         k, p = X.shape
-        beta = WeightedLeastSquares(tau2=tau2)._fit(y, 1/n, X)['beta']
-        sigma = ((y - X.dot(beta))**2 * n).sum() / (k-p) 
+        beta = WeightedLeastSquares(tau2=tau2)._fit(y, n, X)['beta'][:, None]
+        sigma = ((y - X.dot(beta))**2 * n).sum() / (k - p)
         theta_init = np.r_[beta.ravel(), sigma, tau2]
         res = minimize(self._nll_func, theta_init, (y, n, X), **self.kwargs).x
         beta, sigma, tau = res[:-2], float(res[-2]), float(res[-1])
@@ -259,7 +259,7 @@ class SampleSizeBasedLikelihoodEstimator(BaseEstimator):
             sigma2 = 0
         w = 1 / (tau2 + sigma2 / n)
         R = y - X.dot(beta)
-        return 0.5 * (np.log(w).sum() + (R * w * R).sum())
+        return -0.5 * (np.log(w).sum() - (R * w * R).sum())
 
     def _reml_nll(self, theta, y, n, X):
         """ REML negative log-likelihood for meta-regression model. """

--- a/pymare/estimators/estimators.py
+++ b/pymare/estimators/estimators.py
@@ -236,9 +236,11 @@ class SampleSizeBasedLikelihoodEstimator(BaseEstimator):
 
     def _fit(self, y, n, X):
         if n.std() < np.sqrt(np.finfo(float).eps):
-            raise ValueError("Sample size likelihood estimator cannot work with all-equal samples sizes")
-        if n.std() < n.mean()/10:
-            raise Warning("Sample sizes are too close, sample size likelihood estimator may fail")
+            raise ValueError("Sample size-based likelihood estimator cannot "
+                             "work with all-equal sample sizes.")
+        if n.std() < n.mean() / 10:
+            raise Warning("Sample sizes are too close, sample size-based "
+                          "likelihood estimator may fail.")
         # set tau^2 to 0 and compute starting values
         tau2 = 0.
         k, p = X.shape

--- a/pymare/estimators/estimators.py
+++ b/pymare/estimators/estimators.py
@@ -220,10 +220,10 @@ class SampleSizeBasedLikelihoodEstimator(BaseEstimator):
         passed in as keyword arguments.
 
     References:
-        Sangnawakij, P., Böhning, D., Adams, S., Stanton, M., & Holling, H. 
-        (2017). Statistical methodology for estimating the mean difference in 
-        a meta-analysis without  study-specific variance information. Statistics 
-        in Medicine, 36(9), 1395–1413. https://doi.org/10.1002/sim.7232
+        Sangnawakij, P., Böhning, D., Niwitpong, S. A., Adams, S., Stanton, M., 
+        & Holling, H. (2019). Meta-analysis without study-specific variance 
+        information: Heterogeneity case. Statistical Methods in Medical Research, 
+        28(1), 196–210. https://doi.org/10.1177/0962280217718867    
     """
 
     def __init__(self, method='ml', **kwargs):

--- a/pymare/estimators/estimators.py
+++ b/pymare/estimators/estimators.py
@@ -235,6 +235,10 @@ class SampleSizeBasedLikelihoodEstimator(BaseEstimator):
         self.kwargs = kwargs
 
     def _fit(self, y, n, X):
+        if n.std() < np.sqrt(np.finfo(float).eps):
+            raise ValueError("Sample size likelihood estimator cannot work with all-equal samples sizes")
+        if n.std() < n.mean()/10
+            raise Warning("Sample sizes are too close, sample size likelihood estimator may fail")
         # set tau^2 to 0 and compute starting values
         tau2 = 0.
         k, p = X.shape

--- a/pymare/estimators/estimators.py
+++ b/pymare/estimators/estimators.py
@@ -237,7 +237,7 @@ class SampleSizeBasedLikelihoodEstimator(BaseEstimator):
     def _fit(self, y, n, X):
         if n.std() < np.sqrt(np.finfo(float).eps):
             raise ValueError("Sample size likelihood estimator cannot work with all-equal samples sizes")
-        if n.std() < n.mean()/10
+        if n.std() < n.mean()/10:
             raise Warning("Sample sizes are too close, sample size likelihood estimator may fail")
         # set tau^2 to 0 and compute starting values
         tau2 = 0.


### PR DESCRIPTION
Updated version of #18 with some extra patching: adds references and extends the `SampleSizeBasedLikelihoodEstimator` to handle additional covariates (i.e., meta-regression).