### PR TITLE
Permutation testing

### DIFF
--- a/pymare/estimators/estimators.py
+++ b/pymare/estimators/estimators.py
@@ -80,8 +80,8 @@ class BaseEstimator(metaclass=ABCMeta):
 
         Notes:
             This is equivalent to directly accessing `dataset.v` when variances
-            are present, but affords estimators that don't use variances in
-            estimation a way of computing an estimate for downstream use.
+            are present, but affords a way of estimating v from sample size (n)
+            for any estimator that implicitly estimate a sigma^2 parameter.
         """
         if dataset.v is not None:
             return dataset.v
@@ -289,7 +289,7 @@ class VarianceBasedLikelihoodEstimator(BaseEstimator):
 
 class SampleSizeBasedLikelihoodEstimator(BaseEstimator):
     """ Likelihood-based estimator for estimates with known sample sizes but
-    unknown variances.
+    unknown sampling variances.
 
     Iteratively estimates the between-subject variance tau^2 and fixed effect
     betas using the specified likelihood-based estimator (ML or REML).
@@ -306,9 +306,10 @@ class SampleSizeBasedLikelihoodEstimator(BaseEstimator):
             minimizer.
 
     Notes:
-        The ML and REML solutions are obtained via SciPy's scalar function
-        minimizer (scipy.optimize.minimize). Parameters to minimize() can be
-        passed in as keyword arguments.
+        Homogeneity of sigma^2 across studies is assumed. The ML and REML
+        solutions are obtained via SciPy's scalar function minimizer
+        (scipy.optimize.minimize). Parameters to minimize() can be passed in as
+        keyword arguments.
 
     References:
         Sangnawakij, P., Böhning, D., Niwitpong, S. A., Adams, S., Stanton, M., 

--- a/pymare/estimators/estimators.py
+++ b/pymare/estimators/estimators.py
@@ -69,6 +69,33 @@ class BaseEstimator(metaclass=ABCMeta):
         self.dataset_ = dataset
         return self
 
+    def get_v(self, dataset):
+        """Get the variances, or an estimate thereof, from the given Dataset.
+
+        Args:
+            dataset (Dataset): The dataset to use to retrieve/estimate v.
+
+        Returns:
+            A 2-d NDArray.
+
+        Notes:
+            This is equivalent to directly accessing `dataset.v` when variances
+            are present, but affords estimators that don't use variances in
+            estimation a way of computing an estimate for downstream use.
+        """
+        if dataset.v is not None:
+            return dataset.v
+        # Estimate sampling variances from sigma^2 and n if available.
+        if dataset.n is None:
+            raise ValueError("Dataset does not contain sampling variances (v),"
+                             " and no estimate of v is possible without sample"
+                             " sizes (n).")
+        if 'sigma2' not in self.params_:
+            raise ValueError("Dataset does not contain sampling variances (v),"
+                             " and no estimate of v is possible because no "
+                             "sigma^2 parameter was found.")
+        return self.params_['sigma2'] / dataset.n
+
     def summary(self):
         if not hasattr(self, 'params_'):
             name = self.__class__.__name__

--- a/pymare/info.py
+++ b/pymare/info.py
@@ -37,7 +37,8 @@ REQUIRES = [
     'numpy>=1.8.0',
     'scipy',
     'pandas',
-    'sympy'
+    'sympy',
+    'wrapt'
 ]
 
 STAN_REQUIRES = [

--- a/pymare/results.py
+++ b/pymare/results.py
@@ -69,14 +69,8 @@ class MetaRegressionResults:
                 warn("Method 'QP' is not parallelized; it may take a while to "
                      "compute CIs for {} parallel tau^2 values.".format(n_iters))
 
-            # For sample size-based estimator, use sigma2/n instead of
-            # sampling variances. TODO: find a better solution than reaching
-            # into the estimator's stored params, as this could fail if the
-            # estimator has been applied to a different dataset in interim.
-            if self.dataset.v is None:
-                v = self.estimator.params_['sigma2'] / self.dataset.n
-            else:
-                v = self.dataset.v
+            # Make sure we have an estimate of v if it wasn't observed
+            v = self.estimator.get_v(self.dataset)
 
             cis = []
             for i in range(n_iters):
@@ -117,7 +111,7 @@ class MetaRegressionResults:
 
 
 def permutation_test(results, n_perm=1000):
-    """Run permutation test on a MetaRegressionResults instane.
+    """Run permutation test on a MetaRegressionResults instance.
 
     Args:
         results (MetaRegressionResults): The results object to test.
@@ -163,7 +157,7 @@ def permutation_test(results, n_perm=1000):
     for i in range(n_datasets):
 
         y = results.dataset.y[:, i]
-        v = results.dataset.v[:, i]
+        v = results.estimator.get_v(results.dataset)[:, i]
         y_perm = np.repeat(y[:, None], n_perm, axis=1)
         v_perm = np.repeat(v[:, None], n_perm, axis=1)
 

--- a/pymare/results.py
+++ b/pymare/results.py
@@ -112,7 +112,7 @@ class MetaRegressionResults:
         df = df.loc[:, ['name', 'est', 'se', 'z', 'p', 'ci_l', 'ci_u']]
         ci_l = 'ci_{:.6g}'.format(alpha / 2)
         ci_u = 'ci_{:.6g}'.format(1 - alpha / 2)
-        df.columns = ['name', 'estimate', 'se', 'z-score', 'p-val', ci_l, ci_u]
+        df.columns = ['name', 'estimate', 'se', 'z-score', 'p-value', ci_l, ci_u]
         return df
 
 
@@ -205,6 +205,22 @@ class PermutationTestResults:
         self.tau2_p = tau2_p
         self.n_perm = n_perm
         self.exact = exact
+
+    def to_df(self, alpha=0.05):
+        """Export permutation test results as a pandas DF.
+
+        Args:
+            alpha (float): The alpha value to use for confidence intervals.
+
+        Returns:
+            A pandas DataFrame that adds a 'p-value (perm.)' column to the
+            standard fixed effect result table obtained when calling to_df()
+            on a MetaRegressionResults instance.
+        """
+        df = self.results.to_df(alpha)
+        p_ind = list(df.columns).index('p-value')
+        df.insert(p_ind + 1, 'p-value (perm.)', self.fe_p)
+        return df
 
 
 class BayesianMetaRegressionResults:

--- a/pymare/results.py
+++ b/pymare/results.py
@@ -147,7 +147,7 @@ def permutation_test(results, n_perm=1000):
     else:
         n_exact = 2**n_obs
         if n_exact < n_perm:
-            perms = np.array(itertools.product([-1, 1], repeat=n_obs)).T
+            perms = np.array(list(itertools.product([-1, 1], repeat=n_obs))).T
 
     exact = n_exact < n_perm
     if exact:
@@ -181,8 +181,11 @@ def permutation_test(results, n_perm=1000):
 
         params = results.estimator._fit(y=y_perm, v=v_perm, X=results.dataset.X)
 
-        fe_p[:, i] = (fe_stats['est'] < np.abs(params['beta'])).mean(1)
-        tau_p[i] = (re_stats['tau^2'] < np.abs(params['tau2'])).mean()
+        fe_obs = fe_stats['est'][:, i]
+        if fe_obs.ndim == 1:
+            fe_obs = fe_obs[:, None]
+        fe_p[:, i] = (fe_obs < np.abs(params['beta'])).mean(1)
+        tau_p[i] = (re_stats['tau^2'][i] < np.abs(params['tau2'])).mean()
 
     # p-values can't be smaller than 1/n_perm
     fe_p = np.maximum(1/n_perm, fe_p)

--- a/pymare/tests/conftest.py
+++ b/pymare/tests/conftest.py
@@ -18,6 +18,13 @@ def dataset(variables):
 
 
 @pytest.fixture(scope='package')
+def small_dataset_2d(variables):
+    y = np.array([[1.5, 1.9, 2.2], [4, 2, 1]]).T
+    v = np.array([[1, 0.8, 3], [1, 1.5, 1]]).T
+    return Dataset(y, v)
+
+
+@pytest.fixture(scope='package')
 def dataset_2d(variables):
     y, v, X = variables
     y = np.repeat(y, 3, axis=1)

--- a/pymare/tests/test_estimators.py
+++ b/pymare/tests/test_estimators.py
@@ -122,15 +122,15 @@ def test_2d_looping(dataset_2d):
     results = est.summary()
     beta, tau2 = results.fe_params, results.tau2
     assert beta.shape == (2, 3)
-    assert tau2.shape == (3,)
+    assert tau2.shape == (1, 3)
 
     # First and third sets are identical to single dim test; 2nd is different
     assert np.allclose(beta[:, 0], [-0.1072, 0.7653], atol=1e-4)
-    assert np.allclose(tau2[0], 7.7649, atol=1e-4)
+    assert np.allclose(tau2[0, 0], 7.7649, atol=1e-4)
     assert not np.allclose(beta[:, 1], [-0.1072, 0.7653], atol=1e-4)
-    assert not np.allclose(tau2[1], 7.7649, atol=1e-4)
+    assert not np.allclose(tau2[0, 1], 7.7649, atol=1e-4)
     assert np.allclose(beta[:, 2], [-0.1072, 0.7653], atol=1e-4)
-    assert np.allclose(tau2[2], 7.7649, atol=1e-4)
+    assert np.allclose(tau2[0, 2], 7.7649, atol=1e-4)
 
 
 def test_2d_loop_warning(dataset_2d):

--- a/pymare/tests/test_results.py
+++ b/pymare/tests/test_results.py
@@ -1,12 +1,13 @@
 import pytest
 import numpy as np
 
-from pymare.results import MetaRegressionResults, BayesianMetaRegressionResults
+from pymare import Dataset
+from pymare.results import (MetaRegressionResults, permutation_test,
+                            BayesianMetaRegressionResults)
 from pymare.estimators import (WeightedLeastSquares, DerSimonianLaird,
                                VarianceBasedLikelihoodEstimator,
                                SampleSizeBasedLikelihoodEstimator,
                                StanMetaRegression, Hedges)
-
 
 
 @pytest.fixture
@@ -72,9 +73,10 @@ def test_mrr_get_re_stats(results_2d):
 def test_mrr_to_df(results):
     df = results.to_df()
     assert df.shape == (2, 7)
-    col_names = {'estimate', 'p-val', 'z-score', 'ci_0.025', 'ci_0.975', 'se', 'name'}
+    col_names = {'estimate', 'p-value', 'z-score', 'ci_0.025', 'ci_0.975',
+                 'se', 'name'}
     assert set(df.columns) == col_names
-    assert np.allclose(df['p-val'].values, [0.9678, 0.4369], atol=1e-4)
+    assert np.allclose(df['p-value'].values, [0.9678, 0.4369], atol=1e-4)
 
 
 def test_estimator_summary(dataset):
@@ -86,3 +88,33 @@ def test_estimator_summary(dataset):
     est.fit(dataset)
     summary = est.summary()
     assert isinstance(summary, MetaRegressionResults)
+
+
+def test_exact_perm_test_2d_no_mods(small_dataset_2d):
+    results = DerSimonianLaird().fit(small_dataset_2d).summary()
+    pmr = permutation_test(results, 1000)
+    assert pmr.n_perm == 8
+    assert pmr.exact
+    assert isinstance(pmr.results, MetaRegressionResults)
+    assert pmr.fe_p.shape == (1, 2)
+    assert pmr.tau2_p.shape == (2,)
+
+
+def test_approx_perm_test_1d_with_mods(results):
+    pmr = permutation_test(results, 1000)
+    assert pmr.n_perm == 1000
+    assert not pmr.exact
+    assert isinstance(pmr.results, MetaRegressionResults)
+    assert pmr.fe_p.shape == (2, 1)
+    assert pmr.tau2_p.shape == (1,)
+
+
+def test_exact_perm_test_1d_no_mods():
+    dataset = Dataset([1, 1, 2, 1.3], [1.5, 1, 2, 4])
+    results = DerSimonianLaird().fit(dataset).summary()
+    pmr = permutation_test(results, 867)
+    assert pmr.n_perm == 16
+    assert pmr.exact
+    assert isinstance(pmr.results, MetaRegressionResults)
+    assert pmr.fe_p.shape == (1, 1)
+    assert pmr.tau2_p.shape == (1,)

--- a/pymare/tests/test_results.py
+++ b/pymare/tests/test_results.py
@@ -41,7 +41,7 @@ def test_meta_regression_results_init_2d(results_2d):
     assert isinstance(results_2d, MetaRegressionResults)
     assert results_2d.fe_params.shape == (2, 3)
     assert results_2d.fe_cov.shape == (2, 2, 3)
-    assert results_2d.tau2.shape == (3,)
+    assert results_2d.tau2.shape == (1, 3)
 
 
 def test_mrr_fe_se(results, results_2d):
@@ -64,8 +64,9 @@ def test_mrr_get_re_stats(results_2d):
     stats = results_2d.get_re_stats()
     assert isinstance(stats, dict)
     assert set(stats.keys()) == {'tau^2', 'ci_l', 'ci_u'}
-    assert stats['tau^2'].shape == stats['ci_u'].shape == (3,)
-    assert round(stats['tau^2'][2], 4) == 7.7649
+    assert stats['tau^2'].shape == (1, 3)
+    assert stats['ci_u'].shape == (3,)
+    assert round(stats['tau^2'][0, 2], 4) == 7.7649
     assert round(stats['ci_l'][2], 4) == 3.8076
     assert round(stats['ci_u'][2], 2) == 59.61
 
@@ -115,6 +116,16 @@ def test_exact_perm_test_1d_no_mods():
     pmr = permutation_test(results, 867)
     assert pmr.n_perm == 16
     assert pmr.exact
+    assert isinstance(pmr.results, MetaRegressionResults)
+    assert pmr.fe_p.shape == (1, 1)
+    assert pmr.tau2_p.shape == (1,)
+
+
+def test_approx_perm_test_with_n_based_estimator(dataset_n):
+    results = SampleSizeBasedLikelihoodEstimator().fit(dataset_n).summary()
+    pmr = permutation_test(results, 100)
+    assert pmr.n_perm == 100
+    assert not pmr.exact
     assert isinstance(pmr.results, MetaRegressionResults)
     assert pmr.fe_p.shape == (1, 1)
     assert pmr.tau2_p.shape == (1,)


### PR DESCRIPTION
Adds permutation testing: `pymare.results.permutation_test` accepts any `MetaRegressionResult` instance as input, and produces a `PermutationTestResult` instance. Currently all this is really good for is adding a permutation-based p-value, but the basic architecture seems reasonable, so we can expand on this later.

A nice feature is that the permutation testing capitalizes on the dataset vectorization introduced in #26, so, for closed-form estimators, this is really fast.

Closes #18: I initially planned to add bootstrapping-based CIs as well—and probably still will at some point—but I realized that it isn't possible to easily vectorize the bootstrap samples the same way as the permutations (the issue is that the `X` matrix is constant for permutations, but needs to be resampled for bootstrapping, and this breaks the current estimator implementation).