### PR TITLE
[TST, FIX] Add CI step for building docs

### DIFF
--- a/.circleci/artifact_path
+++ b/.circleci/artifact_path
@@ -1,0 +1,1 @@
+0/tmp/src/PyMARE/docs/_build/html/index.html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,24 @@ jobs:
           paths:
             - "/opt/conda/envs/testenv"
 
+  build_docs:
+    working_directory: /tmp/src/PyMARE
+    docker:
+      - image: continuumio/miniconda3
+    steps:
+      - attach_workspace:  # get PyMARE
+          at: /tmp
+      - restore_cache:  # load environment
+          key: deps9-{{ checksum "pymare/info.py" }}
+      - run:
+          name: Build documentation
+          command: |
+            apt-get install -yqq make
+            source activate testenv
+            make -C docs html
+      - store_artifacts:
+          path: /tmp/src/PyMARE/docs/_build/html
+
   coverage_and_tests:
     working_directory: /tmp/src/PyMARE
     docker:
@@ -81,6 +99,12 @@ workflows:
   build_test_deploy:
     jobs:
       - build:
+          filters:
+            tags:
+              only: /.*/
+      - build_docs:
+          requires:
+            - build
           filters:
             tags:
               only: /.*/

--- a/docs/requirements-dev.txt
+++ b/docs/requirements-dev.txt
@@ -2,3 +2,5 @@ sphinx-argparse
 numpydoc
 sphinx_gallery
 m2r
+sphinx_rtd_theme
+sphinx_copybutton

--- a/pymare/info.py
+++ b/pymare/info.py
@@ -60,11 +60,14 @@ TESTS_REQUIRES = [
 ]
 
 DOC_REQUIRES = [
-    'sphinx>=1.5.3',
+    'sphinx~=2.4.2',
     'sphinx_rtd_theme',
     'sphinx-argparse',
     'numpydoc',
-    'm2r'
+    'm2r',
+    'sphinx_copybutton',
+    'sphinx_gallery',
+    'pillow'
 ]
 
 EXTRA_REQUIRES = {


### PR DESCRIPTION
Closes None. Takes approach from pybids, fmriprep, and NiMARE.

Changes proposed in this pull request:
- Add step in CircleCI config for building docs.
- Add artifact_path file with path to doc main page.
- Also, fix the docs (hopefully).