### PR TITLE
[FIX, DOC] Add matplotlib to RTD dependencies

### DIFF
--- a/docs/requirements-dev.txt
+++ b/docs/requirements-dev.txt
@@ -4,3 +4,4 @@ sphinx_gallery
 m2r
 sphinx_rtd_theme
 sphinx_copybutton
+matplotlib

--- a/pymare/info.py
+++ b/pymare/info.py
@@ -67,7 +67,8 @@ DOC_REQUIRES = [
     'm2r',
     'sphinx_copybutton',
     'sphinx_gallery',
-    'pillow'
+    'pillow',
+    'matplotlib'
 ]
 
 EXTRA_REQUIRES = {


### PR DESCRIPTION
RTD is still failing, currently because sphinx_gallery requires matplotlib.