### PR TITLE
ENH: Add heterogeneity test and associated stats

### DIFF
--- a/pymare/results.py
+++ b/pymare/results.py
@@ -106,7 +106,7 @@ class MetaRegressionResults:
         p = ss.chi2.sf(q_fe, df)
         return {
             'Q': q_fe,
-            'p': p,
+            'p(Q)': p,
             'I^2': i2,
             'H': h
         }

--- a/pymare/results.py
+++ b/pymare/results.py
@@ -103,7 +103,7 @@ class MetaRegressionResults:
         df = self.dataset.y.shape[0] - self.dataset.X.shape[1]
         i2 =np.maximum(100. * (q_fe - df) / q_fe, 0.)
         h = np.maximum(np.sqrt(q_fe / df), 1.)
-        p = ss.chi2.cdf(q_fe, df)
+        p = ss.chi2.sf(q_fe, df)
         return {
             'Q': q_fe,
             'p': p,

--- a/pymare/stats.py
+++ b/pymare/stats.py
@@ -90,7 +90,7 @@ def q_profile(y, v, X, alpha=0.05):
 
 
 def q_gen(y, v, X, tau2):
-    """Cochran's Q-statistic.
+    """Generalized form of Cochran's Q-statistic.
 
     Args:
         y (ndarray): 1d array of study-level estimates
@@ -102,9 +102,16 @@ def q_gen(y, v, X, tau2):
 
     Returns:
         A float giving the value of Cochran's Q-statistic.
+
+    References:
+    Veroniki, A. A., Jackson, D., Viechtbauer, W., Bender, R., Bowden, J.,
+    Knapp, G., Kuss, O., Higgins, J. P., Langan, D., & Salanti, G. (2016).
+    Methods to estimate the between-study variance and its uncertainty in
+    meta-analysis. Research synthesis methods, 7(1), 55–79.
+    https://doi.org/10.1002/jrsm.1164
     """
     if np.any(tau2 < 0):
         raise ValueError("Value of tau^2 must be >= 0.")
     beta = weighted_least_squares(y, v, X, tau2)
     w = 1. / (v + tau2)
-    return (w * (y - X.dot(beta)) ** 2).sum()
+    return (w * (y - X.dot(beta)) ** 2).sum(0)

--- a/pymare/tests/test_results.py
+++ b/pymare/tests/test_results.py
@@ -71,6 +71,15 @@ def test_mrr_get_re_stats(results_2d):
     assert round(stats['ci_u'][2], 2) == 59.61
 
 
+def test_mrr_get_heterogeneity_stats(results_2d):
+    stats = results_2d.get_heterogeneity_stats()
+    assert len(stats['Q'] == 3)
+    assert stats['Q'][2].round(4) == 53.8052
+    assert stats['I^2'][0].round(4) == 88.8487
+    assert stats['H'][0].round(4) == 2.9946
+    assert stats['p'][0] < 1e-5
+
+
 def test_mrr_to_df(results):
     df = results.to_df()
     assert df.shape == (2, 7)

--- a/pymare/tests/test_results.py
+++ b/pymare/tests/test_results.py
@@ -74,10 +74,10 @@ def test_mrr_get_re_stats(results_2d):
 def test_mrr_get_heterogeneity_stats(results_2d):
     stats = results_2d.get_heterogeneity_stats()
     assert len(stats['Q'] == 3)
-    assert stats['Q'][2].round(4) == 53.8052
-    assert stats['I^2'][0].round(4) == 88.8487
-    assert stats['H'][0].round(4) == 2.9946
-    assert stats['p'][0] < 1e-5
+    assert round(stats['Q'][2], 4) == 53.8052
+    assert round(stats['I^2'][0], 4) == 88.8487
+    assert round(stats['H'][0], 4) == 2.9946
+    assert stats['p(Q)'][0] < 1e-5
 
 
 def test_mrr_to_df(results):

--- a/pymare/tests/test_stats.py
+++ b/pymare/tests/test_stats.py
@@ -4,7 +4,7 @@ from pymare.stats import q_gen, q_profile
 
 def test_q_gen(vars_with_intercept):
     result = q_gen(*vars_with_intercept, 8)
-    assert round(result, 4) == 8.0161
+    assert round(result[0], 4) == 8.0161
 
 
 def test_q_profile(vars_with_intercept):


### PR DESCRIPTION
Adds heterogeneity test and associated statistics to `MetaRegressionResults` via `get_heterogeneity_stats()`. Currently reports Q (i.e., weighted sum of squared residual error), I^2 (% of error due to heterogeneity), H (ratio of fixed-effects:random-effects SDs), and p-values for Q (by reference to a chi-square distribution with `k - p` DFs).