### PR TITLE
[FIX] Package json file with library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ def main():
     pkg_data = {
         'pymare': [
             'tests/data/*',
-            'resources/*'
+            'resources/*',
+            'effectsize/*.json',
         ]
     }
 


### PR DESCRIPTION
Closes #41.

Adds json files in `effectsize/` to setup `pkg_data` to bundle it with the released library.