### PR TITLE
[FIX] StanMetaRegressionEstimator

### DIFF
--- a/pymare/estimators/estimators.py
+++ b/pymare/estimators/estimators.py
@@ -515,8 +515,8 @@ class StanMetaRegression(BaseEstimator):
         # thetas at the moment. This is sub-optimal in terms of estimation,
         # but allows us to avoid having to add extra logic to detect and
         # handle intercepts in X.
-        spec = f"""
-        data {{
+        spec = """
+        data {
             int<lower=1> N;
             int<lower=1> K;
             vector[N] y;
@@ -524,20 +524,20 @@ class StanMetaRegression(BaseEstimator):
             int<lower=1> C;
             matrix[K, C] X;
             vector[N] sigma;
-        }}
-        parameters {{
+        }
+        parameters {
             vector[C] beta;
             vector[K] theta;
             real<lower=0> tau2;
-        }}
-        transformed parameters {{
+        }
+        transformed parameters {
             vector[N] mu;
             mu = theta[id] + X * beta;
-        }}
-        model {{
+        }
+        model {
             y ~ normal(mu, sigma);
             theta ~ normal(0, tau2);
-        }}
+        }
         """
         from pystan import StanModel
         self.model = StanModel(model_code=spec)

--- a/pymare/estimators/estimators.py
+++ b/pymare/estimators/estimators.py
@@ -542,7 +542,6 @@ class StanMetaRegression(BaseEstimator):
         from pystan import StanModel
         self.model = StanModel(model_code=spec)
 
-    @_loopable
     def _fit(self, y, v, X, groups=None):
         """Run the Stan sampler and return results.
 
@@ -568,6 +567,11 @@ class StanMetaRegression(BaseEstimator):
             `groups` argument can be used to specify the nesting structure
             (i.e., which rows in `y`, `v`, and `X` belong to each study).
         """
+        if y.ndim > 1 and y.shape[1] > 1:
+            raise ValueError("The StanMetaRegression estimator currently does "
+                             "not support 2-dimensional inputs. Passed y has "
+                             "shape {}.".format(y.shape))
+
         if self.model is None:
             self.compile()
 

--- a/pymare/results.py
+++ b/pymare/results.py
@@ -381,11 +381,7 @@ class BayesianMetaRegressionResults:
             A pandas DataFrame, unless the `fmt="xarray"` argument is passed in
             kwargs, in which case an xarray Dataset is returned.
         """
-        var_names = ['fe_params', 'tau2']
-        if include_theta:
-            var_names.append('theta')
-        var_names = kwargs.pop('var_names', var_names)
-        return az.summary(self.data, var_names, **kwargs)
+        return az.summary(self.data, **kwargs)
 
     def plot(self, kind='trace', **kwargs):
         """Generate various plots of the posterior estimates via ArviZ.

--- a/pymare/results.py
+++ b/pymare/results.py
@@ -381,7 +381,11 @@ class BayesianMetaRegressionResults:
             A pandas DataFrame, unless the `fmt="xarray"` argument is passed in
             kwargs, in which case an xarray Dataset is returned.
         """
-        return az.summary(self.data, **kwargs)
+        var_names = ['beta', 'tau2']
+        if include_theta:
+            var_names.append('theta')
+        var_names = kwargs.pop('var_names', var_names)
+        return az.summary(self.data, var_names, **kwargs)
 
     def plot(self, kind='trace', **kwargs):
         """Generate various plots of the posterior estimates via ArviZ.

--- a/pymare/tests/test_stan_estimators.py
+++ b/pymare/tests/test_stan_estimators.py
@@ -6,14 +6,14 @@ from pymare.estimators import StanMetaRegression
 
 def test_stan_estimator(dataset):
     # no ground truth here, so we use sanity checks and rough bounds
-    est = StanMetaRegression(iter=500).fit(dataset)
+    est = StanMetaRegression(iter=3000).fit(dataset)
     results = est.summary()
     assert 'BayesianMetaRegressionResults' == results.__class__.__name__
     summary = results.summary(['beta', 'tau2'])
     beta1, beta2, tau2 = summary['mean'].values[:3]
     assert -0.5 < beta1 < 0.1
     assert 0.6 < beta2 < 0.9
-    assert 2 < tau2 < 6
+    assert 3 < tau2 < 5
 
 
 def test_stan_2d_input_failure(dataset_2d):

--- a/pymare/tests/test_stan_estimators.py
+++ b/pymare/tests/test_stan_estimators.py
@@ -1,11 +1,12 @@
 import numpy as np
+import pytest
 
 from pymare.estimators import StanMetaRegression
 
 
 def test_stan_estimator(dataset):
     # no ground truth here, so we use sanity checks and rough bounds
-    est = StanMetaRegression(iter=2500).fit(dataset)
+    est = StanMetaRegression(iter=500).fit(dataset)
     results = est.summary()
     assert 'BayesianMetaRegressionResults' == results.__class__.__name__
     summary = results.summary(['beta', 'tau2'])
@@ -13,3 +14,9 @@ def test_stan_estimator(dataset):
     assert -0.5 < beta1 < 0.1
     assert 0.6 < beta2 < 0.9
     assert 2 < tau2 < 6
+
+
+def test_stan_2d_input_failure(dataset_2d):
+    with pytest.raises(ValueError) as exc:
+        est = StanMetaRegression(iter=500).fit(dataset_2d)
+    assert str(exc.value).startswith('The StanMetaRegression')


### PR DESCRIPTION
Fixes a bug in the `StanMetaRegressionEstimator`. Also drops an f-string to enable Python 3.5 support, and throws an exception if 2d inputs are passed to the Stan estimator.

Closes #45.