### PR TITLE
Fix combination tests

### DIFF
--- a/pymare/estimators/__init__.py
+++ b/pymare/estimators/__init__.py
@@ -1,7 +1,8 @@
 from .estimators import (WeightedLeastSquares, DerSimonianLaird,
                          VarianceBasedLikelihoodEstimator,
                          SampleSizeBasedLikelihoodEstimator,
-                         StanMetaRegression, Hedges, Stouffers, Fishers)
+                         StanMetaRegression, Hedges)
+from .combination import Stouffers, Fishers
 
 __all__ = [
     'WeightedLeastSquares',

--- a/pymare/estimators/__init__.py
+++ b/pymare/estimators/__init__.py
@@ -2,7 +2,7 @@ from .estimators import (WeightedLeastSquares, DerSimonianLaird,
                          VarianceBasedLikelihoodEstimator,
                          SampleSizeBasedLikelihoodEstimator,
                          StanMetaRegression, Hedges)
-from .combination import Stouffers, Fishers
+from .combination import StoufferCombinationTest, FisherCombinationTest
 
 __all__ = [
     'WeightedLeastSquares',
@@ -11,6 +11,6 @@ __all__ = [
     'SampleSizeBasedLikelihoodEstimator',
     'StanMetaRegression',
     'Hedges',
-    'Stouffers',
-    'Fishers'
+    'StoufferCombinationTest',
+    'FisherCombinationTest'
 ]

--- a/pymare/estimators/combination.py
+++ b/pymare/estimators/combination.py
@@ -1,0 +1,117 @@
+from abc import abstractmethod
+
+import numpy as np
+import scipy.stats as ss
+
+from .estimators import BaseEstimator
+from ..results import CombinationTestResults
+
+
+class CombinationTest(BaseEstimator):
+    """Base class for methods based on combining p/z values."""
+    def __init__(self, mode='one-sided'):
+        mode = mode.lower()
+        if not (mode.startswith('one') or mode.startswith('two') or
+                mode.startswith('conc')):
+            raise ValueError("Invalid mode; must be one of 'one-sided', "
+                             "'two-sided', or 'concordant' (or 'one', 'two',"
+                             "or 'conc' for short).")
+        self.mode = mode
+
+    @abstractmethod
+    def p_value(self, z, *args, **kwargs):
+        pass
+
+    def _fit(self, y, *args, **kwargs):
+        if self.mode.startswith('conc'):
+            ose = self.__class__(mode='one')
+            p1 = ose.p_value(y, *args, **kwargs)
+            p2 = ose.p_value(-y, *args, **kwargs)
+            p = np.maximum(1, 2 * np.minimum(p1, p2))
+        else:
+            p = self.p_value(y, *args, **kwargs)
+        return {'p': p}
+
+    def summary(self):
+        if not hasattr(self, 'params_'):
+            name = self.__class__.__name__
+            raise ValueError("This {} instance hasn't been fitted yet. Please "
+                             "call fit() before summary().".format(name))
+        return CombinationTestResults(self, self.dataset_, self.params_['z'])
+
+
+class Stouffers(CombinationTest):
+    """Stouffer's Z-score meta-analysis method.
+
+    Takes study-level z-scores and combines them via Stouffer's method to
+    produce a fixed-effect estimate of the combined effect.
+
+    Args:
+        input (str): The type of measure passed as the `y` input to fit().
+            Must be one of 'p' (p-values) or 'z' (z-scores).
+        p_type (str) If input == 'p', p_type indicates the type of passed
+            p-values. Valid values:
+                * 'right' (default): one-sided, right-tailed p-values
+                * 'left': one-sided, left-tailed p-values
+                * 'two': two-sided p-values
+
+    Notes:
+        * When passing in two-sided p-values as input, note that sign
+        information is unavailable, and the null being tested is that at least
+        one study deviates from 0 in *either* direction. If one-sided p-value
+        can be computed, users are strongly recommended to pass those instead.
+        (The same caveat applies to 'z' inputs if originally computed from
+        two-sided p-values.)
+        * This estimator does not support meta-regression; any moderators
+        passed in as the X array will be ignored.
+        * The fit() method takes z-scores of p-values as the 'y' input, and
+        (optionally) weights as the 'v' input. If no weights are passed, unit
+        weights are used.
+    """
+    def p_value(self, z, w=None):
+        if self.mode.startswith('two'):
+            z = ss.norm.isf(2 * ss.norm.sf(np.abs(z)))
+        if w is None:
+            w = np.ones_like(z)
+        cz = (z * w).sum(0) / np.sqrt((w**2).sum(0))
+        return ss.norm.sf(cz)
+
+
+class Fishers(CombinationTest):
+    """Fisher's method for combining p-values.
+
+    Takes study-level p-values or z-scores and combines them via Fisher's
+    method to produce a fixed-effect estimate of the combined effect.
+
+    Args:
+        input (str): The type of measure passed as the `y` input to fit().
+            Must be one of 'p' (p-values) or 'z' (z-scores).
+        p_type (str) If input == 'p', p_type indicates the type of passed
+            p-values. Valid values:
+                * 'right' (default): one-sided, right-tailed p-values
+                * 'left': one-sided, left-tailed p-values
+                * 'two': two-sided p-values
+
+    Notes:
+        * When passing in two-sided p-values as input, note that sign
+        information is unavailable, and the null being tested is that at least
+        one study deviates from 0 in *either* direction. If one-sided p-value
+        can be computed, users are strongly recommended to pass those instead.
+        (The same caveat applies to 'z' inputs if originally computed from
+        two-sided p-values.)
+        * This estimator does not support meta-regression; any moderators
+        passed in as the X array will be ignored.
+        * The fit() method takes z-scores or p-values as the `y` input. Studies
+        are weighted equally; the `v` argument will be ignored if passed.
+    """
+    def _z_to_p(self, z):
+        # Transforms the z inputs to p values based on mode of test
+        p = ss.norm.sf(z)
+        if self.mode.startswith('two'):
+            p = 2 * np.minimum(p, 1 - p)
+        return p
+
+    def p_value(self, z):
+        p = self._z_to_p(z)
+        chi2 = -2 * np.log(p).sum(0)
+        return ss.chi2.sf(chi2, 2 * z.shape[0])

--- a/pymare/estimators/combination.py
+++ b/pymare/estimators/combination.py
@@ -41,30 +41,38 @@ class CombinationTest(BaseEstimator):
 class Stouffers(CombinationTest):
     """Stouffer's Z-score meta-analysis method.
 
-    Takes study-level z-scores and combines them via Stouffer's method to
-    produce a fixed-effect estimate of the combined effect.
+    Takes a set of independent z-scores and combines them via Stouffer's method
+    to produce a fixed-effect estimate of the combined effect.
 
     Args:
-        input (str): The type of measure passed as the `y` input to fit().
-            Must be one of 'p' (p-values) or 'z' (z-scores).
-        p_type (str) If input == 'p', p_type indicates the type of passed
-            p-values. Valid values:
-                * 'right' (default): one-sided, right-tailed p-values
-                * 'left': one-sided, left-tailed p-values
-                * 'un': two-sided p-values
+        mode (str): The type of test to perform-- i.e., what null hypothesis to
+            reject. See Winkler et al. (2016) for details. Valid options are:
+                * 'directed': tests a directional hypothesis--i.e., that the
+                    observed value is consistently greater than 0 in the input
+                    studies.
+                * 'undirected': tests an undirected hypothesis--i.e., that the
+                    observed value differs from 0 in the input studies, but
+                    allowing the direction of the deviation to vary by study.
+                * 'concordant': equivalent to two directed tests, one for each
+                    sign, with correction for 2 tests.
 
     Notes:
-        * When passing in two-sided p-values as input, note that sign
-        information is unavailable, and the null being tested is that at least
-        one study deviates from 0 in *either* direction. If one-sided p-value
-        can be computed, users are strongly recommended to pass those instead.
-        (The same caveat applies to 'z' inputs if originally computed from
-        two-sided p-values.)
-        * This estimator does not support meta-regression; any moderators
-        passed in as the X array will be ignored.
-        * The fit() method takes z-scores of p-values as the 'y' input, and
-        (optionally) weights as the 'v' input. If no weights are passed, unit
-        weights are used.
+        (1) All input z-scores are assumed to correspond to one-sided p-values.
+            Do NOT pass in z-scores that have been directly converted from
+            two-tailed p-values, as these do not preserve directional
+            information.
+        (2) The 'directed' and 'undirected' modes are NOT the same as
+            one-tailed and two-tailed tests. In general, users who want to test
+            directed hypotheses should use the 'directed' mode, and users who
+            want to test for consistent effects in either the positive or
+            negative direction should use the 'concordant' mode. The
+            'undirected' mode tests a fairly uncommon null that doesn't
+            constrain the sign of effects to be consistent across studies
+            (one can think of it as a test of extremity). In the vast majority
+            of meta-analysis applications, this mode is not appropriate, and
+            users should instead opt for 'directed' or 'concordant'.
+        (3) This estimator does not support meta-regression; any moderators
+            passed in as the X array will be ignored.
     """
     def p_value(self, z, w=None):
         if self.mode == 'undirected':
@@ -78,29 +86,38 @@ class Stouffers(CombinationTest):
 class Fishers(CombinationTest):
     """Fisher's method for combining p-values.
 
-    Takes study-level p-values or z-scores and combines them via Fisher's
-    method to produce a fixed-effect estimate of the combined effect.
+    Takes a set of independent z-scores and combines them via Fisher's method
+    to produce a fixed-effect estimate of the combined effect.
 
     Args:
-        input (str): The type of measure passed as the `y` input to fit().
-            Must be one of 'p' (p-values) or 'z' (z-scores).
-        p_type (str) If input == 'p', p_type indicates the type of passed
-            p-values. Valid values:
-                * 'right' (default): one-sided, right-tailed p-values
-                * 'left': one-sided, left-tailed p-values
-                * 'un': two-sided p-values
+        mode (str): The type of test to perform-- i.e., what null hypothesis to
+            reject. See Winkler et al. (2016) for details. Valid options are:
+                * 'directed': tests a directional hypothesis--i.e., that the
+                    observed value is consistently greater than 0 in the input
+                    studies.
+                * 'undirected': tests an undirected hypothesis--i.e., that the
+                    observed value differs from 0 in the input studies, but
+                    allowing the direction of the deviation to vary by study.
+                * 'concordant': equivalent to two directed tests, one for each
+                    sign, with correction for 2 tests.
 
     Notes:
-        * When passing in two-sided p-values as input, note that sign
-        information is unavailable, and the null being tested is that at least
-        one study deviates from 0 in *either* direction. If one-sided p-value
-        can be computed, users are strongly recommended to pass those instead.
-        (The same caveat applies to 'z' inputs if originally computed from
-        two-sided p-values.)
-        * This estimator does not support meta-regression; any moderators
-        passed in as the X array will be ignored.
-        * The fit() method takes z-scores or p-values as the `y` input. Studies
-        are weighted equally; the `v` argument will be ignored if passed.
+        (1) All input z-scores are assumed to correspond to one-sided p-values.
+            Do NOT pass in z-scores that have been directly converted from
+            two-tailed p-values, as these do not preserve directional
+            information.
+        (2) The 'directed' and 'undirected' modes are NOT the same as
+            one-tailed and two-tailed tests. In general, users who want to test
+            directed hypotheses should use the 'directed' mode, and users who
+            want to test for consistent effects in either the positive or
+            negative direction should use the 'concordant' mode. The
+            'undirected' mode tests a fairly uncommon null that doesn't
+            constrain the sign of effects to be consistent across studies
+            (one can think of it as a test of extremity). In the vast majority
+            of meta-analysis applications, this mode is not appropriate, and
+            users should instead opt for 'directed' or 'concordant'.
+        (3) This estimator does not support meta-regression; any moderators
+            passed in as the X array will be ignored.
     """
     def _z_to_p(self, z):
         # Transforms the z inputs to p values based on mode of test

--- a/pymare/estimators/combination.py
+++ b/pymare/estimators/combination.py
@@ -31,7 +31,7 @@ class CombinationTest(BaseEstimator):
             ose = self.__class__(mode='directed')
             p1 = ose.p_value(y, *args, **kwargs)
             p2 = ose.p_value(-y, *args, **kwargs)
-            p = np.maximum(1, 2 * np.minimum(p1, p2))
+            p = np.minimum(1, 2 * np.minimum(p1, p2))
         else:
             p = self.p_value(y, *args, **kwargs)
         return {'p': p}
@@ -41,7 +41,7 @@ class CombinationTest(BaseEstimator):
             name = self.__class__.__name__
             raise ValueError("This {} instance hasn't been fitted yet. Please "
                              "call fit() before summary().".format(name))
-        return CombinationTestResults(self, self.dataset_, self.params_['z'])
+        return CombinationTestResults(self, self.dataset_, self.params_['p'])
 
 
 class Stouffers(CombinationTest):
@@ -78,7 +78,7 @@ class Stouffers(CombinationTest):
             of meta-analysis applications, this mode is not appropriate, and
             users should instead opt for 'directed' or 'concordant'.
         (3) This estimator does not support meta-regression; any moderators
-            passed in as the X array will be ignored.
+            passed in to fit() as the X array will be ignored.
     """
     def p_value(self, z, w=None):
         if self.mode == 'undirected':
@@ -123,7 +123,7 @@ class Fishers(CombinationTest):
             of meta-analysis applications, this mode is not appropriate, and
             users should instead opt for 'directed' or 'concordant'.
         (3) This estimator does not support meta-regression; any moderators
-            passed in as the X array will be ignored.
+            passed in to fit() as the X array will be ignored.
     """
     def _z_to_p(self, z):
         # Transforms the z inputs to p values based on mode of test

--- a/pymare/estimators/combination.py
+++ b/pymare/estimators/combination.py
@@ -44,7 +44,7 @@ class CombinationTest(BaseEstimator):
         return CombinationTestResults(self, self.dataset_, self.params_['p'])
 
 
-class Stouffers(CombinationTest):
+class StoufferCombinationTest(CombinationTest):
     """Stouffer's Z-score meta-analysis method.
 
     Takes a set of independent z-scores and combines them via Stouffer's method
@@ -89,7 +89,7 @@ class Stouffers(CombinationTest):
         return ss.norm.sf(cz)
 
 
-class Fishers(CombinationTest):
+class FisherCombinationTest(CombinationTest):
     """Fisher's method for combining p-values.
 
     Takes a set of independent z-scores and combines them via Fisher's method

--- a/pymare/estimators/combination.py
+++ b/pymare/estimators/combination.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+import warnings
 
 import numpy as np
 import scipy.stats as ss
@@ -14,6 +15,11 @@ class CombinationTest(BaseEstimator):
         if mode not in {'directed', 'undirected', 'concordant'}:
             raise ValueError("Invalid mode; must be one of 'directed', "
                              "'undirected', or 'concordant'.")
+        if mode == 'undirected':
+            warnings.warn(
+                "You have opted to conduct an 'undirected' test. Are you sure "
+                "this is what you want? If you're looking for the analog of a "
+                "conventional two-tailed test, use 'concordant'.")
         self.mode = mode
 
     @abstractmethod

--- a/pymare/estimators/combination.py
+++ b/pymare/estimators/combination.py
@@ -46,7 +46,7 @@ class CombinationTest(BaseEstimator):
             name = self.__class__.__name__
             raise ValueError("This {} instance hasn't been fitted yet. Please "
                              "call fit() before summary().".format(name))
-        return CombinationTestResults(self, self.dataset_, self.params_['p'])
+        return CombinationTestResults(self, self.dataset_, p=self.params_['p'])
 
 
 class StoufferCombinationTest(CombinationTest):
@@ -89,7 +89,7 @@ class StoufferCombinationTest(CombinationTest):
         if w is None:
             w = np.ones_like(z)
         cz = (z * w).sum(0) / np.sqrt((w**2).sum(0))
-        return 1 - ss.norm.sf(cz)
+        return ss.norm.sf(cz)
 
 
 class FisherCombinationTest(CombinationTest):

--- a/pymare/results.py
+++ b/pymare/results.py
@@ -244,21 +244,21 @@ class CombinationTestResults:
     @lru_cache(maxsize=1)
     def z(self):
         if self._z is None:
-            self._z = ss.norm.ppf(self.p)
+            self._z = ss.norm.isf(self.p)
         return self._z
 
     @property
     @lru_cache(maxsize=1)
     def p(self):
         if self._p is None:
-            self._p = ss.norm.cdf(self.z)
+            self._p = ss.norm.sf(self.z)
         return self._p
 
     def permutation_test(self, n_perm=1000):
         """Run permutation test.
 
         Args:
-            n_perm (int):Number of permutations to generate. The actual number
+            n_perm (int): Number of permutations to generate. The actual number
                 used may be smaller in the event of an exact test (see below),
                 but will never be larger.
 
@@ -277,7 +277,7 @@ class CombinationTestResults:
         n_obs, n_datasets = self.dataset.y.shape
 
         # create results arrays
-        z_p = np.zeros_like(self.z)
+        p_p = np.zeros_like(self.z)
 
         # Calculate # of permutations and determine whether to use exact test
         n_exact = 2**n_obs
@@ -288,8 +288,8 @@ class CombinationTestResults:
         else:
             exact = False
 
-        # Initialize a new version of the estimator so we can guarantee z input
-        est = self.estimator.__class__(input='z')
+        # Initialize a copy of the estimator to prevent overwriting results
+        est = self.estimator.__class__(mode=self.estimator.mode)
 
         # Loop over parallel datasets
         for i in range(n_datasets):
@@ -303,21 +303,21 @@ class CombinationTestResults:
                 signs = np.random.choice(np.array([-1, 1]), (n_obs, n_perm))
                 y_perm *= signs
 
-            # Pass parameters, remembering that v may actually be n
+            # Some combination tests can handle weights (passed as v)
             kwargs = {'y': y_perm}
             if 'v' in getfullargspec(est._fit).args:
                 kwargs['v'] = self.dataset.v
             params = est._fit(**kwargs)
 
-            z_obs = self.z[i]
-            if z_obs.ndim == 1:
-                z_obs = z_obs[:, None]
-            z_p[i] = (z_obs > params['z']).mean()
+            p_obs = self.z[i]
+            if p_obs.ndim == 1:
+                p_obs = p_obs[:, None]
+            p_p[i] = (p_obs > params['p']).mean()
 
         # p-values can't be smaller than 1/n_perm
-        z_p = np.maximum(1 / n_perm, z_p)
+        p_p = np.maximum(1 / n_perm, p_p)
 
-        return PermutationTestResults(self, {'fe_p': z_p}, n_perm, exact)
+        return PermutationTestResults(self, {'fe_p': p_p}, n_perm, exact)
 
 
 class PermutationTestResults:

--- a/pymare/tests/test_combination_tests.py
+++ b/pymare/tests/test_combination_tests.py
@@ -1,0 +1,33 @@
+import numpy as np
+import scipy.stats as ss
+
+from pymare.estimators import Stouffers, Fishers
+
+
+def test_stouffers():
+    # One-tailed, 1-d
+    z = np.array([2.1, 0.7, -0.2, 4.1, 3.8])[:, None]
+    results = Stouffers()._fit(z)
+    res_z = ss.norm.isf(results['p'])
+    assert np.allclose(res_z, [4.69574], atol=1e-5)
+
+    # 2-d with weights
+    z = np.c_[z, np.array([-0.6, -1.61, -2.3, -0.8, -4.01])[:, None]]
+    w = np.array([2, 1, 1, 2, 2])[:, None]
+    results = Stouffers()._fit(z, w)
+    res_z = ss.norm.isf(results['p'])
+    assert np.allclose(res_z, [5.47885, -3.93675], atol=1e-5)
+
+
+def test_fishers():
+    # 1-d
+    z = np.array([2.1, 0.7, -0.2, 4.1, 3.8])[:, None]
+    results = Fishers()._fit(z)
+    res_z = ss.norm.isf(results['p'])
+    assert np.allclose(res_z, [5.22413541], atol=1e-5)
+
+    # 2-d
+    z = np.c_[z, np.array([-0.6, -1.61, -2.3, -0.8, -4.01])[:, None]]
+    results = Fishers()._fit(z)
+    res_z = ss.norm.isf(results['p'])
+    assert np.allclose(res_z, [5.22413541, -3.30626405], atol=1e-5)

--- a/pymare/tests/test_combination_tests.py
+++ b/pymare/tests/test_combination_tests.py
@@ -3,12 +3,13 @@ import scipy.stats as ss
 import pytest
 
 from pymare.estimators import StoufferCombinationTest, FisherCombinationTest
+from pymare import Dataset
 
 
 _z1 = np.array([2.1, 0.7, -0.2, 4.1, 3.8])[:, None]
 _z2 = np.c_[_z1, np.array([-0.6, -1.61, -2.3, -0.8, -4.01])[:, None]]
 
-params = [
+_params = [
     (StoufferCombinationTest, _z1, 'directed', [4.69574]),
     (StoufferCombinationTest, _z1, 'undirected', [4.87462819]),
     (StoufferCombinationTest, _z1, 'concordant', [4.55204117]),
@@ -24,9 +25,17 @@ params = [
 ]
 
 
-@pytest.mark.parametrize("Cls,data,mode,expected", params)
+@pytest.mark.parametrize("Cls,data,mode,expected", _params)
 def test_combination_test(Cls, data, mode, expected):
     results = Cls(mode)._fit(data)
     z = ss.norm.isf(results['p'])
-    print(z, expected)
+    assert np.allclose(z, expected, atol=1e-5)
+
+
+@pytest.mark.parametrize("Cls,data,mode,expected", _params)
+def test_combination_test_from_dataset(Cls, data, mode, expected):
+    dset = Dataset(y=data)
+    est = Cls(mode).fit(dset)
+    results = est.summary()
+    z = ss.norm.isf(results.p)
     assert np.allclose(z, expected, atol=1e-5)

--- a/pymare/tests/test_combination_tests.py
+++ b/pymare/tests/test_combination_tests.py
@@ -1,33 +1,32 @@
 import numpy as np
 import scipy.stats as ss
+import pytest
 
 from pymare.estimators import StoufferCombinationTest, FisherCombinationTest
 
 
-def test_stouffer_undirected():
-    # One-tailed, 1-d
-    z = np.array([2.1, 0.7, -0.2, 4.1, 3.8])[:, None]
-    results = StoufferCombinationTest()._fit(z)
-    res_z = ss.norm.isf(results['p'])
-    assert np.allclose(res_z, [4.69574], atol=1e-5)
+_z1 = np.array([2.1, 0.7, -0.2, 4.1, 3.8])[:, None]
+_z2 = np.c_[_z1, np.array([-0.6, -1.61, -2.3, -0.8, -4.01])[:, None]]
 
-    # 2-d with weights
-    z = np.c_[z, np.array([-0.6, -1.61, -2.3, -0.8, -4.01])[:, None]]
-    w = np.array([2, 1, 1, 2, 2])[:, None]
-    results = StoufferCombinationTest()._fit(z, w)
-    res_z = ss.norm.isf(results['p'])
-    assert np.allclose(res_z, [5.47885, -3.93675], atol=1e-5)
+params = [
+    (StoufferCombinationTest, _z1, 'directed', [4.69574]),
+    (StoufferCombinationTest, _z1, 'undirected', [4.87462819]),
+    (StoufferCombinationTest, _z1, 'concordant', [4.55204117]),
+    (StoufferCombinationTest, _z2, 'directed', [4.69574275, -4.16803071]),
+    (StoufferCombinationTest, _z2, 'undirected', [4.87462819, 4.16803071]),
+    (StoufferCombinationTest, _z2, 'concordant', [4.55204117, 4.00717817]),
+    (FisherCombinationTest, _z1, 'directed', [5.22413541]),
+    (FisherCombinationTest, _z1, 'undirected', [5.27449962]),
+    (FisherCombinationTest, _z1, 'concordant', [5.09434911]),
+    (FisherCombinationTest, _z2, 'directed', [5.22413541, -3.30626405]),
+    (FisherCombinationTest, _z2, 'undirected', [5.27449962, 4.27572965]),
+    (FisherCombinationTest, _z2, 'concordant', [5.09434911, 4.11869468]),
+]
 
 
-def test_fisher_undirected():
-    # 1-d
-    z = np.array([2.1, 0.7, -0.2, 4.1, 3.8])[:, None]
-    results = FisherCombinationTest()._fit(z)
-    res_z = ss.norm.isf(results['p'])
-    assert np.allclose(res_z, [5.22413541], atol=1e-5)
-
-    # 2-d
-    z = np.c_[z, np.array([-0.6, -1.61, -2.3, -0.8, -4.01])[:, None]]
-    results = FisherCombinationTest()._fit(z)
-    res_z = ss.norm.isf(results['p'])
-    assert np.allclose(res_z, [5.22413541, -3.30626405], atol=1e-5)
+@pytest.mark.parametrize("Cls,data,mode,expected", params)
+def test_combination_test(Cls, data, mode, expected):
+    results = Cls(mode)._fit(data)
+    z = ss.norm.isf(results['p'])
+    print(z, expected)
+    assert np.allclose(z, expected, atol=1e-5)

--- a/pymare/tests/test_combination_tests.py
+++ b/pymare/tests/test_combination_tests.py
@@ -1,33 +1,33 @@
 import numpy as np
 import scipy.stats as ss
 
-from pymare.estimators import Stouffers, Fishers
+from pymare.estimators import StoufferCombinationTest, FisherCombinationTest
 
 
-def test_stouffers():
+def test_stouffer_undirected():
     # One-tailed, 1-d
     z = np.array([2.1, 0.7, -0.2, 4.1, 3.8])[:, None]
-    results = Stouffers()._fit(z)
+    results = StoufferCombinationTest()._fit(z)
     res_z = ss.norm.isf(results['p'])
     assert np.allclose(res_z, [4.69574], atol=1e-5)
 
     # 2-d with weights
     z = np.c_[z, np.array([-0.6, -1.61, -2.3, -0.8, -4.01])[:, None]]
     w = np.array([2, 1, 1, 2, 2])[:, None]
-    results = Stouffers()._fit(z, w)
+    results = StoufferCombinationTest()._fit(z, w)
     res_z = ss.norm.isf(results['p'])
     assert np.allclose(res_z, [5.47885, -3.93675], atol=1e-5)
 
 
-def test_fishers():
+def test_fisher_undirected():
     # 1-d
     z = np.array([2.1, 0.7, -0.2, 4.1, 3.8])[:, None]
-    results = Fishers()._fit(z)
+    results = FisherCombinationTest()._fit(z)
     res_z = ss.norm.isf(results['p'])
     assert np.allclose(res_z, [5.22413541], atol=1e-5)
 
     # 2-d
     z = np.c_[z, np.array([-0.6, -1.61, -2.3, -0.8, -4.01])[:, None]]
-    results = Fishers()._fit(z)
+    results = FisherCombinationTest()._fit(z)
     res_z = ss.norm.isf(results['p'])
     assert np.allclose(res_z, [5.22413541, -3.30626405], atol=1e-5)

--- a/pymare/tests/test_estimators.py
+++ b/pymare/tests/test_estimators.py
@@ -3,7 +3,7 @@ import pytest
 from pymare.estimators import (WeightedLeastSquares, DerSimonianLaird,
                                VarianceBasedLikelihoodEstimator,
                                SampleSizeBasedLikelihoodEstimator,
-                               StanMetaRegression, Hedges, Stouffers, Fishers)
+                               StanMetaRegression, Hedges)
 from pymare import Dataset
 
 
@@ -115,31 +115,6 @@ def test_sample_size_based_restricted_maximum_likelihood_estimator(dataset_n):
     assert np.allclose(beta, [-2.1071], atol=1e-4)
     assert np.allclose(sigma2, 13.048, atol=1e-3)
     assert np.allclose(tau2, 3.2177, atol=1e-4)
-
-
-def test_stouffers():
-    # 1-d
-    z = np.array([2.1, 0.7, -0.2, 4.1, 3.8])[:, None]
-    results = Stouffers()._fit(z)
-    assert np.allclose(results['z'], [4.69574], atol=1e-5)
-
-    # 2-d with weights
-    z = np.c_[z, np.array([-0.6, -1.61, -2.3, -0.8, -4.01])[:, None]]
-    w = np.array([2, 1, 1, 2, 2])[:, None]
-    results = Stouffers()._fit(z, w)['z'].ravel()
-    assert np.allclose(results, [5.47885, -3.93675], atol=1e-5)
-
-
-def test_fishers():
-    # 1-d
-    z = np.array([2.1, 0.7, -0.2, 4.1, 3.8])[:, None]
-    results = Fishers()._fit(z)
-    assert np.allclose(results['z'], [2.469052], atol=1e-5)
-
-    # 2-d
-    z = np.c_[z, np.array([-0.6, -1.61, -2.3, -0.8, -4.01])[:, None]]
-    results = Fishers()._fit(z)['z'].ravel()
-    assert np.allclose(results, [2.469052, -4.27573], atol=1e-5)
 
 
 def test_2d_looping(dataset_2d):

--- a/pymare/tests/test_results.py
+++ b/pymare/tests/test_results.py
@@ -7,7 +7,8 @@ from pymare.results import (MetaRegressionResults, CombinationTestResults,
 from pymare.estimators import (WeightedLeastSquares, DerSimonianLaird,
                                VarianceBasedLikelihoodEstimator,
                                SampleSizeBasedLikelihoodEstimator,
-                               StanMetaRegression, Hedges, Stouffers)
+                               StanMetaRegression, Hedges,
+                               StoufferCombinationTest, FisherCombinationTest)
 
 
 @pytest.fixture
@@ -142,7 +143,7 @@ def test_approx_perm_test_with_n_based_estimator(dataset_n):
 
 def test_stouffers_perm_test_exact():
     dataset = Dataset([1, 1, 2, 1.3], [1.5, 1, 2, 4])
-    results = Stouffers().fit(dataset).summary()
+    results = StoufferCombinationTest().fit(dataset).summary()
     pmr = results.permutation_test(2000)
     assert pmr.n_perm == 16
     assert pmr.exact
@@ -154,11 +155,10 @@ def test_stouffers_perm_test_exact():
 def test_stouffers_perm_test_approx():
     y = [2.8, -0.2, -1, 4.5, 1.9, 2.38, 0.6, 1.88, -0.4, 1.5, 3.163, 0.7]
     dataset = Dataset(y)
-    results = Stouffers().fit(dataset).summary()
+    results = StoufferCombinationTest().fit(dataset).summary()
     pmr = results.permutation_test(2000)
     assert not pmr.exact
     assert pmr.n_perm == 2000
     assert isinstance(pmr.results, CombinationTestResults)
     assert pmr.perm_p['fe_p'].shape == (1,)
     assert 'tau2_p' not in pmr.perm_p
-


### PR DESCRIPTION
Fixes/improves the combination test implementations (Stouffer's and Fisher's methods):

* Moves combination tests into their own module.
* Simplifies internal logic of base `CombinationTest` class.
* Fixes problems with returned p-values (#36).
* Adds concordant and directed test modes (see #39).
* Adds nicely parameterized tests.

This leaves some inconsistencies with the results returned by other estimators, and I have some ideas for improving/simplifying the handling of `Dataset` inputs, but I'll merge this first to keep things modular.

Closes #36.
Closes #39.