### PR TITLE
[REF] Improved Dataset fitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,25 @@ from pymare.estimators import VarianceBasedLikelihoodEstimator
 dataset = Dataset(y, v, X)
 # Estimator class for likelihood-based methods when variances are known
 estimator = VarianceBasedLikelihoodEstimator(method='REML')
-# All estimators accept a `Dataset` instance as the first argument to `.fit()`
-estimator.fit(dataset)
+# All estimators expose a fit_dataset() method that takes a `Dataset`
+# instance as the first (and usually only) argument.
+estimator.fit_dataset(dataset)
 # Post-fitting we can obtain a MetaRegressionResults instance via .summary()
 results = estimator.summary()
 # Print summary of results as a pandas DataFrame
 print(result.to_df())
+```
+
+And if we want to be even more explicit, we can avoid the `Dataset` abstraction
+entirely (though we'll lose some convenient validation checks):
+
+```python
+estimator = VarianceBasedLikelihoodEstimator(method='REML')
+
+# X must be 2-d; this is one of the things the Dataset implicitly handles.
+X = X[:, None]
+
+estimator.fit(y, v, X)
+
+results = estimator.summary()
 ```

--- a/examples/02_meta-analysis/plot_run_meta-analysis.py
+++ b/examples/02_meta-analysis/plot_run_meta-analysis.py
@@ -29,6 +29,6 @@ n = np.random.randint(5, 50, size=n_studies)
 # Datasets can also be created from pandas DataFrames
 # ---------------------------------------------------
 dataset = core.Dataset(v=v, X=X, y=y, n=n)
-est = estimators.WeightedLeastSquares().fit(dataset)
+est = estimators.WeightedLeastSquares().fit_dataset(dataset)
 results = est.summary()
 print(results.to_df())

--- a/pymare/core.py
+++ b/pymare/core.py
@@ -144,5 +144,5 @@ def meta_regression(y=None, v=None, X=None, n=None, data=None, X_names=None,
 
     # Get estimates
     est = est_cls(**kwargs)
-    est.fit(data)
+    est.fit_dataset(data)
     return est.summary()

--- a/pymare/estimators/combination.py
+++ b/pymare/estimators/combination.py
@@ -85,6 +85,10 @@ class StoufferCombinationTest(CombinationTest):
         (3) This estimator does not support meta-regression; any moderators
             passed in to fit() as the X array will be ignored.
     """
+
+    # Maps Dataset attributes onto fit() args; see BaseEstimator for details.
+    _dataset_attr_map = {'z': 'y', 'w': 'v'}
+
     def p_value(self, z, w=None):
         if w is None:
             w = np.ones_like(z)
@@ -128,6 +132,10 @@ class FisherCombinationTest(CombinationTest):
         (3) This estimator does not support meta-regression; any moderators
             passed in to fit() as the X array will be ignored.
     """
+
+    # Maps Dataset attributes onto fit() args; see BaseEstimator for details.
+    _dataset_attr_map = {'z': 'y'}
+
     def p_value(self, z):
         p = self._z_to_p(z)
         chi2 = -2 * np.log(p).sum(0)

--- a/pymare/estimators/combination.py
+++ b/pymare/estimators/combination.py
@@ -29,7 +29,7 @@ class CombinationTest(BaseEstimator):
     def _z_to_p(self, z):
         return ss.norm.sf(z)
 
-    def _fit(self, y, *args, **kwargs):
+    def fit(self, y, *args, **kwargs):
         if self.mode == 'concordant':
             ose = self.__class__(mode='directed')
             p1 = ose.p_value(y, *args, **kwargs)

--- a/pymare/estimators/combination.py
+++ b/pymare/estimators/combination.py
@@ -29,16 +29,16 @@ class CombinationTest(BaseEstimator):
     def _z_to_p(self, z):
         return ss.norm.sf(z)
 
-    def fit(self, y, *args, **kwargs):
+    def fit(self, z, *args, **kwargs):
         if self.mode == 'concordant':
             ose = self.__class__(mode='directed')
-            p1 = ose.p_value(y, *args, **kwargs)
-            p2 = ose.p_value(-y, *args, **kwargs)
+            p1 = ose.p_value(z, *args, **kwargs)
+            p2 = ose.p_value(-z, *args, **kwargs)
             p = np.minimum(1, 2 * np.minimum(p1, p2))
         else:
             if self.mode == 'undirected':
-                y = np.abs(y)
-            p = self.p_value(y, *args, **kwargs)
+                z = np.abs(z)
+            p = self.p_value(z, *args, **kwargs)
         return {'p': p}
 
     def summary(self):

--- a/pymare/estimators/combination.py
+++ b/pymare/estimators/combination.py
@@ -39,7 +39,8 @@ class CombinationTest(BaseEstimator):
             if self.mode == 'undirected':
                 z = np.abs(z)
             p = self.p_value(z, *args, **kwargs)
-        return {'p': p}
+        self.params_ = {'p': p}
+        return self
 
     def summary(self):
         if not hasattr(self, 'params_'):
@@ -88,6 +89,9 @@ class StoufferCombinationTest(CombinationTest):
 
     # Maps Dataset attributes onto fit() args; see BaseEstimator for details.
     _dataset_attr_map = {'z': 'y', 'w': 'v'}
+
+    def fit(self, z, w=None):
+        return super().fit(z, w=w)
 
     def p_value(self, z, w=None):
         if w is None:

--- a/pymare/estimators/estimators.py
+++ b/pymare/estimators/estimators.py
@@ -74,12 +74,12 @@ class BaseEstimator(metaclass=ABCMeta):
 
         for i, name in enumerate(spec.args[1:]):
             # Check for remapped name
-            arg_name = self._dataset_attr_map.get(name, name)
+            attr_name = self._dataset_attr_map.get(name, name)
             if i >= n_args:
-                all_kwargs[arg_name] = getattr(dataset, name,
+                all_kwargs[name] = getattr(dataset, attr_name,
                                            spec.defaults[i - n_args])
             else:
-                all_kwargs[arg_name] = getattr(dataset, name)
+                all_kwargs[name] = getattr(dataset, attr_name)
 
         all_kwargs.update(kwargs)
         self.params_ = self.fit(*args, **all_kwargs)

--- a/pymare/results.py
+++ b/pymare/results.py
@@ -203,7 +203,7 @@ class MetaRegressionResults:
             # Pass parameters, remembering that v may actually be n
             kwargs = {'y': y_perm, 'X': self.dataset.X}
             kwargs['v' if has_v else 'n'] = v_perm
-            params = self.estimator.fit(**kwargs)
+            params = self.estimator.fit(**kwargs).params_
 
             fe_obs = fe_stats['est'][:, i]
             if fe_obs.ndim == 1:
@@ -304,10 +304,10 @@ class CombinationTestResults:
                 y_perm *= signs
 
             # Some combination tests can handle weights (passed as v)
-            kwargs = {'y': y_perm}
-            if 'v' in getfullargspec(est.fit).args:
-                kwargs['v'] = self.dataset.v
-            params = est.fit(**kwargs)
+            kwargs = {'z': y_perm}
+            if 'w' in getfullargspec(est.fit).args:
+                kwargs['w'] = self.dataset.v
+            params = est.fit(**kwargs).params_
 
             p_obs = self.z[i]
             if p_obs.ndim == 1:

--- a/pymare/results.py
+++ b/pymare/results.py
@@ -177,7 +177,7 @@ class MetaRegressionResults:
             y_perm = np.repeat(y[:, None], n_perm, axis=1)
 
             # for v, we might actually be working with n, depending on estimator
-            has_v = 'v' in getfullargspec(self.estimator._fit).args[1:]
+            has_v = 'v' in getfullargspec(self.estimator.fit).args[1:]
             v = self.dataset.v[:, i] if has_v else self.dataset.n[:, i]
 
             v_perm = np.repeat(v[:, None], n_perm, axis=1)
@@ -203,7 +203,7 @@ class MetaRegressionResults:
             # Pass parameters, remembering that v may actually be n
             kwargs = {'y': y_perm, 'X': self.dataset.X}
             kwargs['v' if has_v else 'n'] = v_perm
-            params = self.estimator._fit(**kwargs)
+            params = self.estimator.fit(**kwargs)
 
             fe_obs = fe_stats['est'][:, i]
             if fe_obs.ndim == 1:
@@ -305,9 +305,9 @@ class CombinationTestResults:
 
             # Some combination tests can handle weights (passed as v)
             kwargs = {'y': y_perm}
-            if 'v' in getfullargspec(est._fit).args:
+            if 'v' in getfullargspec(est.fit).args:
                 kwargs['v'] = self.dataset.v
-            params = est._fit(**kwargs)
+            params = est.fit(**kwargs)
 
             p_obs = self.z[i]
             if p_obs.ndim == 1:

--- a/pymare/tests/test_combination_tests.py
+++ b/pymare/tests/test_combination_tests.py
@@ -27,7 +27,7 @@ _params = [
 
 @pytest.mark.parametrize("Cls,data,mode,expected", _params)
 def test_combination_test(Cls, data, mode, expected):
-    results = Cls(mode).fit(data)
+    results = Cls(mode).fit(data).params_
     z = ss.norm.isf(results['p'])
     assert np.allclose(z, expected, atol=1e-5)
 

--- a/pymare/tests/test_combination_tests.py
+++ b/pymare/tests/test_combination_tests.py
@@ -27,7 +27,7 @@ _params = [
 
 @pytest.mark.parametrize("Cls,data,mode,expected", _params)
 def test_combination_test(Cls, data, mode, expected):
-    results = Cls(mode)._fit(data)
+    results = Cls(mode).fit(data)
     z = ss.norm.isf(results['p'])
     assert np.allclose(z, expected, atol=1e-5)
 
@@ -35,7 +35,7 @@ def test_combination_test(Cls, data, mode, expected):
 @pytest.mark.parametrize("Cls,data,mode,expected", _params)
 def test_combination_test_from_dataset(Cls, data, mode, expected):
     dset = Dataset(y=data)
-    est = Cls(mode).fit(dset)
+    est = Cls(mode).fit_dataset(dset)
     results = est.summary()
     z = ss.norm.isf(results.p)
     assert np.allclose(z, expected, atol=1e-5)

--- a/pymare/tests/test_estimators.py
+++ b/pymare/tests/test_estimators.py
@@ -9,14 +9,14 @@ from pymare import Dataset
 
 def test_weighted_least_squares_estimator(dataset):
     # ground truth values are from metafor package in R
-    est = WeightedLeastSquares().fit(dataset)
+    est = WeightedLeastSquares().fit_dataset(dataset)
     results = est.summary()
     beta, tau2 = results.fe_params, results.tau2
     assert np.allclose(beta.ravel(), [-0.2725, 0.6935], atol=1e-4)
     assert tau2 == 0.
 
     # With non-zero tau^2
-    est = WeightedLeastSquares(8.).fit(dataset)
+    est = WeightedLeastSquares(8.).fit_dataset(dataset)
     results = est.summary()
     beta, tau2 = results.fe_params, results.tau2
     assert np.allclose(beta.ravel(), [-0.1071, 0.7657], atol=1e-4)
@@ -25,7 +25,7 @@ def test_weighted_least_squares_estimator(dataset):
 
 def test_dersimonian_laird_estimator(dataset):
     # ground truth values are from metafor package in R
-    est = DerSimonianLaird().fit(dataset)
+    est = DerSimonianLaird().fit_dataset(dataset)
     results = est.summary()
     beta, tau2 = results.fe_params, results.tau2
     assert np.allclose(beta.ravel(), [-0.1070, 0.7664], atol=1e-4)
@@ -33,7 +33,7 @@ def test_dersimonian_laird_estimator(dataset):
 
 
 def test_2d_DL_estimator(dataset_2d):
-    results = DerSimonianLaird().fit(dataset_2d).summary()
+    results = DerSimonianLaird().fit_dataset(dataset_2d).summary()
     beta, tau2 = results.fe_params, results.tau2
     assert beta.shape == (2, 3)
     assert tau2.shape == (3,)
@@ -52,7 +52,7 @@ def test_hedges_estimator(dataset):
     # ground truth values are from metafor package in R, except that metafor
     # always gives negligibly different values for tau2, likely due to
     # algorithmic differences in the computation.
-    est = Hedges().fit(dataset)
+    est = Hedges().fit_dataset(dataset)
     results = est.summary()
     beta, tau2 = results.fe_params, results.tau2
     assert np.allclose(beta.ravel(), [-0.1066, 0.7704], atol=1e-4)
@@ -60,7 +60,7 @@ def test_hedges_estimator(dataset):
 
 
 def test_2d_hedges(dataset_2d):
-    results = Hedges().fit(dataset_2d).summary()
+    results = Hedges().fit_dataset(dataset_2d).summary()
     beta, tau2 = results.fe_params, results.tau2
     assert beta.shape == (2, 3)
     assert tau2.shape == (3,)
@@ -77,7 +77,7 @@ def test_2d_hedges(dataset_2d):
 
 def test_variance_based_maximum_likelihood_estimator(dataset):
     # ground truth values are from metafor package in R
-    est = VarianceBasedLikelihoodEstimator(method='ML').fit(dataset)
+    est = VarianceBasedLikelihoodEstimator(method='ML').fit_dataset(dataset)
     results = est.summary()
     beta, tau2 = results.fe_params, results.tau2
     assert np.allclose(beta.ravel(), [-0.1072, 0.7653], atol=1e-4)
@@ -86,7 +86,7 @@ def test_variance_based_maximum_likelihood_estimator(dataset):
 
 def test_variance_based_restricted_maximum_likelihood_estimator(dataset):
     # ground truth values are from metafor package in R
-    est = VarianceBasedLikelihoodEstimator(method='REML').fit(dataset)
+    est = VarianceBasedLikelihoodEstimator(method='REML').fit_dataset(dataset)
     results = est.summary()
     beta, tau2 = results.fe_params, results.tau2
     assert np.allclose(beta.ravel(), [-0.1066, 0.7700], atol=1e-4)
@@ -95,7 +95,7 @@ def test_variance_based_restricted_maximum_likelihood_estimator(dataset):
 
 def test_sample_size_based_maximum_likelihood_estimator(dataset_n):
     # test values have not been verified for convergence with other packages
-    est = SampleSizeBasedLikelihoodEstimator(method='ML').fit(dataset_n)
+    est = SampleSizeBasedLikelihoodEstimator(method='ML').fit_dataset(dataset_n)
     results = est.summary()
     beta = results.fe_params
     sigma2 = results.estimator.params_['sigma2']
@@ -107,7 +107,7 @@ def test_sample_size_based_maximum_likelihood_estimator(dataset_n):
 
 def test_sample_size_based_restricted_maximum_likelihood_estimator(dataset_n):
     # test values have not been verified for convergence with other packages
-    est = SampleSizeBasedLikelihoodEstimator(method='REML').fit(dataset_n)
+    est = SampleSizeBasedLikelihoodEstimator(method='REML').fit_dataset(dataset_n)
     results = est.summary()
     beta = results.fe_params
     sigma2 = results.estimator.params_['sigma2']
@@ -118,7 +118,7 @@ def test_sample_size_based_restricted_maximum_likelihood_estimator(dataset_n):
 
 
 def test_2d_looping(dataset_2d):
-    est = VarianceBasedLikelihoodEstimator().fit(dataset_2d)
+    est = VarianceBasedLikelihoodEstimator().fit_dataset(dataset_2d)
     results = est.summary()
     beta, tau2 = results.fe_params, results.tau2
     assert beta.shape == (2, 3)
@@ -140,6 +140,6 @@ def test_2d_loop_warning(dataset_2d):
     dataset = Dataset(y, v)
     # Warning is raised when 2nd dim is > 10
     with pytest.warns(UserWarning, match='Input contains'):
-        est.fit(dataset)
+        est.fit_dataset(dataset)
     # But not when it's smaller
-    est.fit(dataset_2d)
+    est.fit_dataset(dataset_2d)

--- a/pymare/tests/test_results.py
+++ b/pymare/tests/test_results.py
@@ -14,7 +14,7 @@ from pymare.estimators import (WeightedLeastSquares, DerSimonianLaird,
 @pytest.fixture
 def fitted_estimator(dataset):
     est = DerSimonianLaird()
-    return est.fit(dataset)
+    return est.fit_dataset(dataset)
 
 
 @pytest.fixture
@@ -25,7 +25,7 @@ def results(fitted_estimator):
 @pytest.fixture
 def results_2d(fitted_estimator, dataset_2d):
     est = VarianceBasedLikelihoodEstimator()
-    return est.fit(dataset_2d).summary()
+    return est.fit_dataset(dataset_2d).summary()
 
 
 def test_meta_regression_results_init_1d(fitted_estimator):
@@ -96,13 +96,13 @@ def test_estimator_summary(dataset):
     with pytest.raises(ValueError):
         results = est.summary()
     
-    est.fit(dataset)
+    est.fit_dataset(dataset)
     summary = est.summary()
     assert isinstance(summary, MetaRegressionResults)
 
 
 def test_exact_perm_test_2d_no_mods(small_dataset_2d):
-    results = DerSimonianLaird().fit(small_dataset_2d).summary()
+    results = DerSimonianLaird().fit_dataset(small_dataset_2d).summary()
     pmr = results.permutation_test(1000)
     assert pmr.n_perm == 8
     assert pmr.exact
@@ -122,7 +122,7 @@ def test_approx_perm_test_1d_with_mods(results):
 
 def test_exact_perm_test_1d_no_mods():
     dataset = Dataset([1, 1, 2, 1.3], [1.5, 1, 2, 4])
-    results = DerSimonianLaird().fit(dataset).summary()
+    results = DerSimonianLaird().fit_dataset(dataset).summary()
     pmr = results.permutation_test(867)
     assert pmr.n_perm == 16
     assert pmr.exact
@@ -132,7 +132,7 @@ def test_exact_perm_test_1d_no_mods():
 
 
 def test_approx_perm_test_with_n_based_estimator(dataset_n):
-    results = SampleSizeBasedLikelihoodEstimator().fit(dataset_n).summary()
+    results = SampleSizeBasedLikelihoodEstimator().fit_dataset(dataset_n).summary()
     pmr = results.permutation_test(100)
     assert pmr.n_perm == 100
     assert not pmr.exact
@@ -143,7 +143,7 @@ def test_approx_perm_test_with_n_based_estimator(dataset_n):
 
 def test_stouffers_perm_test_exact():
     dataset = Dataset([1, 1, 2, 1.3], [1.5, 1, 2, 4])
-    results = StoufferCombinationTest().fit(dataset).summary()
+    results = StoufferCombinationTest().fit_dataset(dataset).summary()
     pmr = results.permutation_test(2000)
     assert pmr.n_perm == 16
     assert pmr.exact
@@ -155,7 +155,7 @@ def test_stouffers_perm_test_exact():
 def test_stouffers_perm_test_approx():
     y = [2.8, -0.2, -1, 4.5, 1.9, 2.38, 0.6, 1.88, -0.4, 1.5, 3.163, 0.7]
     dataset = Dataset(y)
-    results = StoufferCombinationTest().fit(dataset).summary()
+    results = StoufferCombinationTest().fit_dataset(dataset).summary()
     pmr = results.permutation_test(2000)
     assert not pmr.exact
     assert pmr.n_perm == 2000

--- a/pymare/tests/test_stan_estimators.py
+++ b/pymare/tests/test_stan_estimators.py
@@ -6,7 +6,7 @@ from pymare.estimators import StanMetaRegression
 
 def test_stan_estimator(dataset):
     # no ground truth here, so we use sanity checks and rough bounds
-    est = StanMetaRegression(iter=3000).fit(dataset)
+    est = StanMetaRegression(iter=3000).fit_dataset(dataset)
     results = est.summary()
     assert 'BayesianMetaRegressionResults' == results.__class__.__name__
     summary = results.summary(['beta', 'tau2'])
@@ -18,5 +18,5 @@ def test_stan_estimator(dataset):
 
 def test_stan_2d_input_failure(dataset_2d):
     with pytest.raises(ValueError) as exc:
-        est = StanMetaRegression(iter=500).fit(dataset_2d)
+        est = StanMetaRegression(iter=500).fit_dataset(dataset_2d)
     assert str(exc.value).startswith('The StanMetaRegression')


### PR DESCRIPTION
Makes some API changes for improved `Dataset` handling and more sklearn-like behavior:
* The `fit()` method in estimator classes no longer takes `Dataset` instances; it now takes numpy arrays.
* The internal `_fit()` methods have been removed in favor of the public `fit()` methods.
* The old `fit()` behavior can now be reproduced by calling`fit_dataset()`.
* All `fit()` methods now return `self` instead of the fitted parameters (which are stored in `.params_`).

@tsalo I expect this will break NiMARE's IBMA classes; I can patch this myself if you like, but I expect it should be as simple as either renaming `fit_()` to `fit()` everywhere, or using `fit_dataset()` instead of `fit()`, depending on which pattern you're currently using. And I'm guessing you'll probably need to explicitly retrieve `params_` instead of just using the return value from `fit()`.