### PR TITLE
[FIX] minimization issues

### DIFF
--- a/pymare/estimators/estimators.py
+++ b/pymare/estimators/estimators.py
@@ -9,7 +9,7 @@ from scipy.optimize import minimize, Bounds
 from scipy import stats as ss
 import wrapt
 
-from ..stats import weighted_least_squares
+from ..stats import weighted_least_squares, ensure_2d
 from ..results import (MetaRegressionResults, BayesianMetaRegressionResults,
                        CombinationTestResults)
 
@@ -187,6 +187,10 @@ class DerSimonianLaird(BaseEstimator):
     """
 
     def fit(self, y, v, X):
+
+        y = ensure_2d(y)
+        v = ensure_2d(v)
+
         k, p = X.shape
 
         # Estimate initial betas with WLS, assuming tau^2=0

--- a/pymare/results.py
+++ b/pymare/results.py
@@ -83,7 +83,12 @@ class MetaRegressionResults:
                     'X': self.dataset.X,
                     'alpha': alpha,
                 }
-                q_cis = q_profile(**args)
+
+                try:
+                    q_cis = q_profile(**args)
+                except Exception as exc:
+                    q_cis = {'ci_l': np.nan, 'ci_u': np.nan}
+
                 cis.append(q_cis)
 
         else:

--- a/pymare/stats.py
+++ b/pymare/stats.py
@@ -86,7 +86,7 @@ def q_profile(y, v, X, alpha=0.05):
     # Use the D-L estimate of tau^2 as a starting point; when using a fixed
     # value, minimize() sometimes fails to stay in bounds.
     from .estimators import DerSimonianLaird
-    ub_start = DerSimonianLaird().fit(y, v, X).params_['tau2']
+    ub_start = 2 * DerSimonianLaird().fit(y, v, X).params_['tau2']
 
     lb = minimize(lambda x: (q_gen(*args, x) - l_crit)**2, [0],
                   bounds=bds).x[0]

--- a/pymare/stats.py
+++ b/pymare/stats.py
@@ -82,9 +82,15 @@ def q_profile(y, v, X, alpha=0.05):
     u_crit = ss.chi2.ppf(alpha / 2, df)
     args = (ensure_2d(y), ensure_2d(v), X)
     bds = Bounds([0], [np.inf], keep_feasible=True)
+
+    # Use the D-L estimate of tau^2 as a starting point; when using a fixed
+    # value, minimize() sometimes fails to stay in bounds.
+    from .estimators import DerSimonianLaird
+    ub_start = DerSimonianLaird().fit(y, v, X).params_['tau2']
+
     lb = minimize(lambda x: (q_gen(*args, x) - l_crit)**2, [0],
                   bounds=bds).x[0]
-    ub = minimize(lambda x: (q_gen(*args, x) - u_crit)**2, [100],
+    ub = minimize(lambda x: (q_gen(*args, x) - u_crit)**2, [ub_start],
                   bounds=bds).x[0]
     return {'ci_l': lb, 'ci_u': ub}
 

--- a/pymare/tests/test_stats.py
+++ b/pymare/tests/test_stats.py
@@ -11,4 +11,4 @@ def test_q_profile(vars_with_intercept):
     bounds = q_profile(*vars_with_intercept, 0.05)
     assert set(bounds.keys()) == {'ci_l', 'ci_u'}
     assert round(bounds['ci_l'], 4) == 3.8076
-    assert round(bounds['ci_u'], 4) == 59.6144
+    assert round(bounds['ci_u'], 2) == 59.61


### PR DESCRIPTION
To avoid optimization failures in `q_profile()` (see discussion in #40), we now pick a starting value for the upper CI of tau^2 based on the data (double the Dersimonian-Laird estimate of tau^2). This should hopefully work better than using a constant value. But, seeing as there will probably still be some non-zero rate of failure, we also now catch exceptions and set the CI values to `NaN`.

Closes #40.
