### PR TITLE
[CI] Relax Codecov coverage requirements

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,12 +7,12 @@ coverage:
     project:
       default:
         # basic
-        target: 0
-        threshold: null
+        target: auto
+        threshold: 2%
     patch:
       default:
-        target: 0
-        threshold: null
+        target: auto
+        threshold: 2%
   ignore:
     - 'pymare/tests/'
     - 'pymare/_version.py'


### PR DESCRIPTION
Lowers codecov coverage requirements so tests don't fail any time coverage goes down (unless the decrease >= 2%).

Closes #53