### PR TITLE
Add Zenodo badges to documentation

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -4,6 +4,11 @@
       "name": "Yarkoni, Tal",
       "affiliation": "University of Texas at Austin",
       "orcid": "0000-0002-6558-5113"
+    },
+    {
+      "name": "Salo, Taylor",
+      "affiliation": "Florida International University",
+      "orcid": "0000-0001-9813-3167"
     }
   ],
   "keywords": [

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A Python library for mixed-effects meta-regression (including meta-analysis).
 [![Latest Version](https://img.shields.io/pypi/v/pymare.svg)](https://pypi.python.org/pypi/pymare/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pymare.svg)](https://pypi.python.org/pypi/pymare/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![DOI](https://zenodo.org/badge/228903736.svg)](https://zenodo.org/badge/latestdoi/228903736)
 [![Documentation Status](https://readthedocs.org/projects/pymare/badge/?version=latest)](http://pymare.readthedocs.io/en/latest/?badge=latest)
 ![GitHub CI](https://github.com/neurostuff/pymare/actions/workflows/testing.yml/badge.svg)
 [![Codecov](https://codecov.io/gh/neurostuff/PyMARE/branch/master/graph/badge.svg)](https://codecov.io/gh/neurostuff/pymare)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,10 @@ PyMARE is a Python package for meta-analyses and meta-regressions.
   :target: https://opensource.org/licenses/MIT
   :alt: License
 
+.. image:: https://zenodo.org/badge/228903736.svg
+   :target: https://zenodo.org/badge/latestdoi/228903736
+   :alt: Zenodo
+
 .. image:: https://github.com/neurostuff/pymare/actions/workflows/testing.yml/badge.svg
   :target: https://github.com/neurostuff/pymare/actions/workflows/testing.yml/badge.svg
   :alt: GitHub CI


### PR DESCRIPTION
Closes #31.

Changes proposed:

- Add Zenodo badges to README and docs/index.rst.
- Add myself to the Zenodo file.