### PR TITLE
Run unit tests automatically every Sunday

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - '*'
+  schedule:
+    # Run tests every Sunday at 12am
+    - cron: '0 0 * * 0'
 
 concurrency:
   group: environment-${{ github.ref }}


### PR DESCRIPTION
Closes #76. Given the low activity in this repository, this new job should catch issues with new versions of dependencies.