### PR TITLE
Use BibTeX for references and improve docstrings

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -91,7 +91,6 @@ API
 
    :template: function.rst
    effectsize.solve_system
-   effectsize.Expression
    effectsize.select_expressions
    effectsize.compute_measure
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,6 +53,7 @@ extensions = [
     "sphinx_copybutton",  # for copying code snippets
     "sphinx_gallery.gen_gallery",  # example gallery
     "sphinxarg.ext",  # argparse
+    "sphinxcontrib.bibtex",  # for foot-citations
     "recommonmark",  # markdown parser
 ]
 
@@ -187,6 +188,14 @@ sphinx_gallery_conf = {
 
 # Generate the plots for the gallery
 plot_gallery = True
+
+# -----------------------------------------------------------------------------
+# sphinxcontrib-bibtex
+# -----------------------------------------------------------------------------
+bibtex_bibfiles = ["./references.bib"]
+bibtex_style = "unsrt"
+bibtex_reference_style = "author_year"
+bibtex_footbibliography_header = ""
 
 
 def setup(app):

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -35,6 +35,15 @@
   doi={10.1093/biomet/asx001}
 }
 
+@article{fisher1946statistical,
+  title={Statistical methods for research workers.},
+  author={Fisher, Ronald Aylmer and others},
+  journal={Statistical methods for research workers.},
+  number={10th. ed.},
+  year={1946},
+  publisher={Oliver and Boyd}
+}
+
 @book{hedges2014statistical,
   title={Statistical methods for meta-analysis},
   author={Hedges, Larry V and Olkin, Ingram},
@@ -79,6 +88,14 @@
   doi={10.1177/0962280217718867}
 }
 
+@article{stouffer1949american,
+  title={The american soldier: Adjustment during army life.(studies in social psychology in world war ii), vol. 1},
+  author={Stouffer, Samuel A and Suchman, Edward A and DeVinney, Leland C and Star, Shirley A and Williams Jr, Robin M},
+  journal={Studies in social psychology in World War II},
+  year={1949},
+  publisher={Princeton Univ. Press}
+}
+
 @article{veroniki2016methods,
   title={Methods to estimate the between-study variance and its uncertainty in meta-analysis},
   author={Veroniki, Areti Angeliki and Jackson, Dan and Viechtbauer, Wolfgang and Bender, Ralf and Bowden, Jack and Knapp, Guido and Kuss, Oliver and Higgins, Julian PT and Langan, Dean and Salanti, Georgia},
@@ -103,4 +120,17 @@
   publisher={Wiley Online Library},
   url={https://doi.org/10.1002/sim.2514},
   doi={10.1002/sim.2514}
+}
+
+@article{winkler2016non,
+  title={Non-parametric combination and related permutation tests for neuroimaging},
+  author={Winkler, Anderson M and Webster, Matthew A and Brooks, Jonathan C and Tracey, Irene and Smith, Stephen M and Nichols, Thomas E},
+  journal={Human brain mapping},
+  volume={37},
+  number={4},
+  pages={1486--1511},
+  year={2016},
+  publisher={Wiley Online Library},
+  url={https://doi.org/10.1002/hbm.23115},
+  doi={10.1002/hbm.23115}
 }

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,0 +1,106 @@
+@article{brockwell2001comparison,
+  title={A comparison of statistical methods for meta-analysis},
+  author={Brockwell, Sarah E and Gordon, Ian R},
+  journal={Statistics in medicine},
+  volume={20},
+  number={6},
+  pages={825--840},
+  year={2001},
+  publisher={Wiley Online Library},
+  url={https://doi.org/10.1002/sim.650},
+  doi={10.1002/sim.650}
+}
+
+@article{cochran1954combination,
+  title={The combination of estimates from different experiments},
+  author={Cochran, William G},
+  journal={Biometrics},
+  volume={10},
+  number={1},
+  pages={101--129},
+  year={1954},
+  publisher={JSTOR}
+}
+
+@article{dersimonian1986meta,
+  title={Meta-analysis in clinical trials},
+  author={DerSimonian, Rebecca and Laird, Nan},
+  journal={Controlled clinical trials},
+  volume={7},
+  number={3},
+  pages={177--188},
+  year={1986},
+  publisher={Elsevier},
+  url={https://doi.org/10.1093/biomet/asx001},
+  doi={10.1093/biomet/asx001}
+}
+
+@book{hedges2014statistical,
+  title={Statistical methods for meta-analysis},
+  author={Hedges, Larry V and Olkin, Ingram},
+  year={2014},
+  publisher={Academic press}
+}
+
+@article{higgins2002quantifying,
+  title={Quantifying heterogeneity in a meta-analysis},
+  author={Higgins, Julian PT and Thompson, Simon G},
+  journal={Statistics in medicine},
+  volume={21},
+  number={11},
+  pages={1539--1558},
+  year={2002},
+  publisher={Wiley Online Library}
+}
+
+@article{kosmidis2017improving,
+  title={Improving the accuracy of likelihood-based inference in meta-analysis and meta-regression},
+  author={Kosmidis, Ioannis and Guolo, Annamaria and Varin, Cristiano},
+  journal={Biometrika},
+  volume={104},
+  number={2},
+  pages={489--496},
+  year={2017},
+  publisher={Oxford University Press},
+  url={https://doi.org/10.1093/biomet/asx001},
+  doi={10.1093/biomet/asx001}
+}
+
+@article{sangnawakij2019meta,
+  title={Meta-analysis without study-specific variance information: Heterogeneity case},
+  author={Sangnawakij, Patarawan and B{\"o}hning, Dankmar and Niwitpong, Sa-Aat and Adams, Stephen and Stanton, Michael and Holling, Heinz},
+  journal={Statistical Methods in Medical Research},
+  volume={28},
+  number={1},
+  pages={196--210},
+  year={2019},
+  publisher={SAGE Publications Sage UK: London, England},
+  url={https://doi.org/10.1177/0962280217718867},
+  doi={10.1177/0962280217718867}
+}
+
+@article{veroniki2016methods,
+  title={Methods to estimate the between-study variance and its uncertainty in meta-analysis},
+  author={Veroniki, Areti Angeliki and Jackson, Dan and Viechtbauer, Wolfgang and Bender, Ralf and Bowden, Jack and Knapp, Guido and Kuss, Oliver and Higgins, Julian PT and Langan, Dean and Salanti, Georgia},
+  journal={Research synthesis methods},
+  volume={7},
+  number={1},
+  pages={55--79},
+  year={2016},
+  publisher={Wiley Online Library},
+  url={https://doi.org/10.1002/jrsm.1164},
+  doi={10.1002/jrsm.1164}
+}
+
+@article{viechtbauer2007confidence,
+  title={Confidence intervals for the amount of heterogeneity in meta-analysis},
+  author={Viechtbauer, Wolfgang},
+  journal={Statistics in medicine},
+  volume={26},
+  number={1},
+  pages={37--52},
+  year={2007},
+  publisher={Wiley Online Library},
+  url={https://doi.org/10.1002/sim.2514},
+  doi={10.1002/sim.2514}
+}

--- a/pymare/core.py
+++ b/pymare/core.py
@@ -24,34 +24,34 @@ class Dataset:
     y : None or :obj:`numpy.ndarray` of shape (K,) or :obj:`str`, optional
         1d array of study-level estimates with length K, or the name of the column in data
         containing the y values.
-        Default is None.
+        Default = None.
     v : None or :obj:`numpy.ndarray` of shape (K,) or :obj:`str`, optional
         1d array of study-level variances with length K, or the name of the column in data
         containing v values.
-        Default is None.
+        Default = None.
     X : None or :obj:`numpy.ndarray` of shape (K,[P]) or :obj:`list` of :obj:`str`, optional
         1d or 2d array containing study-level predictors (dimensions K x P),
         or a list of strings giving the names of the columns in data containing the X values.
-        Default is None.
+        Default = None.
     n : None or :obj:`numpy.ndarray` of shape (K,) or :obj:`str`, optional
         1d array of study-level sample sizes (length K), or the name of the corresponding column
         in ``data``.
-        Default is None.
+        Default = None.
     data : None or :obj:`pandas.DataFrame`, optional
         A pandas DataFrame containing y, v, X, and/or n values.
         By default, columns are expected to have the same names as arguments
         (e.g., the y values will be expected in the 'y' column).
         This can be modified by passing strings giving column names to any of the ``y``, ``v``,
         ``X``, or ``n`` arguments.
-        Default is None.
+        Default = None.
     X_names : None or :obj:`list` of :obj:`str`, optional
         List of length P containing the names of the predictors.
         Ignored if ``data`` is provided (use ``X`` to specify columns).
-        Default is None.
+        Default = None.
     add_intercept : :obj:`bool`, optional
         If True, an intercept column is automatically added to the predictor matrix.
         If False, the predictors matrix is passed as-is to estimators.
-        Default is True.
+        Default = True.
     """
 
     def __init__(
@@ -114,19 +114,19 @@ def meta_regression(
     y : None or :obj:`numpy.ndarray` of shape (K,) or :obj:`str`, optional
         1d array of study-level estimates with length K, or the name of the column in data
         containing the y values.
-        Default is None.
+        Default = None.
     v : None or :obj:`numpy.ndarray` of shape (K,) or :obj:`str`, optional
         1d array of study-level variances with length K, or the name of the column in data
         containing v values.
-        Default is None.
+        Default = None.
     X : None or :obj:`numpy.ndarray` of shape (K,[P]) or :obj:`list` of :obj:`str`, optional
         1d or 2d array containing study-level predictors (dimensions K x P),
         or a list of strings giving the names of the columns in data containing the X values.
-        Default is None.
+        Default = None.
     n : None or :obj:`numpy.ndarray` of shape (K,) or :obj:`str`, optional
         1d array of study-level sample sizes (length K), or the name of the corresponding column
         in ``data``.
-        Default is None.
+        Default = None.
     data : None or :obj:`pandas.DataFrame` or :obj:`~pymare.core.Dataset`, optional
         If a Dataset instance is passed, the y, v, X, n and associated arguments are ignored,
         and data is passed directly to the selected estimator.
@@ -138,13 +138,13 @@ def meta_regression(
     X_names : None or :obj:`list` of :obj:`str`, optional
         List of length P containing the names of the predictors.
         Ignored if ``data`` is provided (use ``X`` to specify columns).
-        Default is None.
+        Default = None.
     add_intercept : :obj:`bool`, optional
         If True, an intercept column is automatically added to the predictor matrix.
         If False, the predictors matrix is passed as-is to estimators.
-        Default is True.
+        Default = True.
     method : {"ML", "REML", "DL", "HE", "WLS", "FE", "Stan"}, optional
-        Name of estimation method. Default is 'ML'.
+        Name of estimation method. Default = 'ML'.
         Supported estimators include:
 
             - 'ML': Maximum-likelihood estimator
@@ -155,10 +155,10 @@ def meta_regression(
             - 'Stan': Full Bayesian MCMC estimation via Stan
     ci_method : {"QP"}, optional
         Estimation method to use when computing uncertainty estimates.
-        Currently only 'QP' is supported. Default is 'QP'.
+        Currently only 'QP' is supported. Default = 'QP'.
         Ignored if ``method == 'Stan'``.
     alpha : :obj:`float`, optional
-        Desired alpha level (CIs will have 1 - alpha coverage). Default is 0.05.
+        Desired alpha level (CIs will have 1 - alpha coverage). Default = 0.05.
     **kwargs
         Optional keyword arguments to pass onto the chosen estimator.
 

--- a/pymare/effectsize/base.py
+++ b/pymare/effectsize/base.py
@@ -25,7 +25,7 @@ def solve_system(system, known_vars=None):
         A dictionary of known variables to use
         when evaluating the solution. Keys are the names of parameters
         (e.g., 'sem', 't'), values are numerical data types (including
-        numpy arrays). Default is None.
+        numpy arrays). Default = None.
 
     Returns
     -------
@@ -134,7 +134,7 @@ class EffectSizeConverter(metaclass=ABCMeta):
         incremental : :obj:`bool`, optional
             If True, updates data incrementally (i.e., existing data will be preserved unless
             they're overwritten by incoming keys). If False, all existing data is dropped first.
-            Default is False.
+            Default = False.
         **kwargs
             Data values or arrays; keys are the names of the quantities.
             All inputs to ``__init__`` are valid.
@@ -231,7 +231,7 @@ class OneSampleEffectSizeConverter(EffectSizeConverter):
         Column names must match the controlled names listed below for
         kwargs. If additional kwargs are provided, they will take
         precedence over the values in the data frame.
-        Default is None.
+        Default = None.
     m : None or :obj:`numpy.ndarray`, optional
         Means or other continuous estimates
     sd : None or :obj:`numpy.ndarray`, optional

--- a/pymare/estimators/combination.py
+++ b/pymare/estimators/combination.py
@@ -62,14 +62,15 @@ class CombinationTest(BaseEstimator):
 class StoufferCombinationTest(CombinationTest):
     """Stouffer's Z-score meta-analysis method.
 
-    Takes a set of independent z-scores and combines them via Stouffer's method
-    to produce a fixed-effect estimate of the combined effect.
+    Takes a set of independent z-scores and combines them via Stouffer's
+    :footcite:p:`stouffer1949american` method to produce a fixed-effect estimate of the combined
+    effect.
 
     Parameters
     ----------
     mode : {"directed", "undirected", "concordant"}, optional
-        The type of test to perform-- i.e., what null hypothesis to
-        reject. See Winkler et al. (2016) for details.
+        The type of test to perform-- i.e., what null hypothesis to reject.
+        See :footcite:t:`winkler2016non` for details.
         Valid options are:
 
         -   'directed': tests a directional hypothesis--i.e., that the
@@ -99,6 +100,10 @@ class StoufferCombinationTest(CombinationTest):
         users should instead opt for 'directed' or 'concordant'.
     (3) This estimator does not support meta-regression; any moderators
         passed in to fit() as the X array will be ignored.
+
+    References
+    ----------
+    .. footbibliography::
     """
 
     # Maps Dataset attributes onto fit() args; see BaseEstimator for details.
@@ -119,14 +124,18 @@ class StoufferCombinationTest(CombinationTest):
 class FisherCombinationTest(CombinationTest):
     """Fisher's method for combining p-values.
 
-    Takes a set of independent z-scores and combines them via Fisher's method
-    to produce a fixed-effect estimate of the combined effect.
+    Takes a set of independent z-scores and combines them via Fisher's
+    :footcite:p:`fisher1946statistical` method to produce a fixed-effect estimate of the combined
+    effect.
 
+    Parameters
+    ----------
     mode : {"directed", "undirected", "concordant"}, optional
-        The type of test to perform-- i.e., what null hypothesis to
-        reject. See Winkler et al. (2016) for details. Valid options are:
+        The type of test to perform-- i.e., what null hypothesis to reject.
+        See :footcite:t:`winkler2016non` for details.
+        Valid options are:
 
-            -  'directed': tests a directional hypothesis--i.e., that the
+            -   'directed': tests a directional hypothesis--i.e., that the
                 observed value is consistently greater than 0 in the input
                 studies. This is the default.
             -   'undirected': tests an undirected hypothesis--i.e., that the
@@ -153,6 +162,10 @@ class FisherCombinationTest(CombinationTest):
         users should instead opt for 'directed' or 'concordant'.
     (3) This estimator does not support meta-regression; any moderators
         passed in to fit() as the X array will be ignored.
+
+    References
+    ----------
+    .. footbibliography::
     """
 
     # Maps Dataset attributes onto fit() args; see BaseEstimator for details.

--- a/pymare/estimators/estimators.py
+++ b/pymare/estimators/estimators.py
@@ -116,7 +116,7 @@ class BaseEstimator(metaclass=ABCMeta):
 
         Notes
         -----
-        This is equivalent to directly accessing `dataset.v` when variances are present,
+        This is equivalent to directly accessing ``dataset.v`` when variances are present,
         but affords a way of estimating v from sample size (n) for any estimator that implicitly
         estimates a sigma^2 parameter.
         """

--- a/pymare/estimators/estimators.py
+++ b/pymare/estimators/estimators.py
@@ -150,31 +150,30 @@ class BaseEstimator(metaclass=ABCMeta):
 class WeightedLeastSquares(BaseEstimator):
     """Weighted least-squares meta-regression.
 
-    Provides the weighted least-squares estimate of the fixed effects given
-    known/assumed between-study variance tau^2. When tau^2 = 0 (default), the
-    model is the standard inverse-weighted fixed-effects meta-regression.
+    Provides the weighted least-squares estimate of the fixed effects given known/assumed
+    between-study variance tau^2, as described in :footcite:t:`brockwell2001comparison`.
+    When tau^2 = 0 (default), the model is the standard inverse-weighted fixed-effects
+    meta-regression.
 
     Parameters
     ----------
     tau2 : :obj:`float` or :obj:`numpy.ndarray` of shape (d), optional
         Assumed/known value of tau^2. Must be >= 0.
         If an array, must have ``d`` elements, where ``d`` refers to the number of datasets.
-        Defaults to 0.
+        Default = 0.
 
     Notes
     -----
-    This estimator accepts 2-D inputs for y and v--i.e., it can produce
-    estimates simultaneously for multiple independent sets of y/v values
-    (use the 2nd dimension for the parallel iterates). The X matrix must be
-    identical for all iterates. If no v argument is passed to fit(), unit
-    weights will be used, resulting in the ordinary least-squares (OLS)
-    solution.
+    This estimator accepts 2-D inputs for ``y`` and ``v``--i.e., it can produce estimates
+    simultaneously for multiple independent sets of ``y``/``v`` values
+    (use the 2nd dimension for the parallel iterates).
+    The ``X`` matrix must be identical for all iterates.
+    If no ``v`` argument is passed to :meth:`fit`, unit weights will be used, resulting in the
+    ordinary least-squares (OLS) solution.
 
     References
     ----------
-    Brockwell, S. E., & Gordon, I. R. (2001). A comparison of statistical
-    methods for meta-analysis. Statistics in Medicine, 20(6), 825-840.
-    https://doi.org/10.1002/sim.650
+    .. footbibliography::
     """
 
     def __init__(self, tau2=0.0):
@@ -192,23 +191,19 @@ class WeightedLeastSquares(BaseEstimator):
 class DerSimonianLaird(BaseEstimator):
     """DerSimonian-Laird meta-regression estimator.
 
-    Estimates the between-subject variance tau^2 using the DerSimonian-Laird
-    (1986) method-of-moments approach.
+    Estimates the between-subject variance tau^2 using the :footcite:t:`dersimonian1986meta`
+    method-of-moments approach.
 
     Notes
     -----
-    This estimator accepts 2-D inputs for y and v--i.e., it can produce
-    estimates simultaneously for multiple independent sets of y/v values
-    (use the 2nd dimension for the parallel iterates). The X matrix must be
-    identical for all iterates.
+    This estimator accepts 2-D inputs for ``y`` and ``v``--i.e., it can produce estimates
+    simultaneously for multiple independent sets of ``y``/``v`` values
+    (use the 2nd dimension for the parallel iterates).
+    The ``X`` matrix must be identical for all iterates.
 
     References
     ----------
-    DerSimonian, R., & Laird, N. (1986). Meta-analysis in clinical trials.
-    Controlled clinical trials, 7(3), 177-188.
-    Kosmidis, I., Guolo, A., & Varin, C. (2017). Improving the accuracy of
-    likelihood-based inference in meta-analysis and meta-regression.
-    Biometrika, 104(2), 489-496. https://doi.org/10.1093/biomet/asx001
+    .. footbibliography::
     """
 
     def fit(self, y, v, X):
@@ -221,7 +216,7 @@ class DerSimonianLaird(BaseEstimator):
         # Estimate initial betas with WLS, assuming tau^2=0
         beta_wls, inv_cov = weighted_least_squares(y, v, X, return_cov=True)
 
-        # Cochrane's Q
+        # Cochran's Q
         w = 1.0 / v
         w_sum = w.sum(0)
         Q = (w * (y - X.dot(beta_wls)) ** 2).sum(0)
@@ -243,18 +238,19 @@ class DerSimonianLaird(BaseEstimator):
 class Hedges(BaseEstimator):
     """Hedges meta-regression estimator.
 
-    Estimates the between-subject variance tau^2 using the Hedges & Olkin (1985) approach.
+    Estimates the between-subject variance tau^2 using the :footcite:t:`hedges2014statistical`
+    approach.
 
     Notes
     -----
-    This estimator accepts 2-D inputs for y and v--i.e., it can produce
-    estimates simultaneously for multiple independent sets of y/v values
-    (use the 2nd dimension for the parallel iterates). The X matrix must be
-    identical for all iterates.
+    This estimator accepts 2-D inputs for ``y`` and ``v``--i.e., it can produce estimates
+    simultaneously for multiple independent sets of ``y``/``v`` values
+    (use the 2nd dimension for the parallel iterates).
+    The ``X`` matrix must be identical for all iterates.
 
     References
     ----------
-    Hedges LV, Olkin I. 1985. Statistical Methods for Meta-Analysis.
+    .. footbibliography::
     """
 
     def fit(self, y, v, X):
@@ -274,31 +270,29 @@ class Hedges(BaseEstimator):
 class VarianceBasedLikelihoodEstimator(BaseEstimator):
     """Likelihood-based estimator for estimates with known variances.
 
-    Iteratively estimates the between-subject variance tau^2 and fixed effect
-    coefficients using the specified likelihood-based estimator (ML or REML).
+    Initially estimates the between-subject variance tau^2 and fixed effect coefficients
+    using :footcite:t:`dersimonian1986meta` method-of-moments approach, and then
+    iteratively estimates them using the specified likelihood-based estimator (ML or REML)
+    :footcite:p:`kosmidis2017improving`.
 
     Parameters
     ----------
     method : {"ML", "REML"}, optional
         The estimation method to use. Either 'ML' (for
         maximum-likelihood) or 'REML' (restricted maximum-likelihood).
-        Defaults to 'ML'.
+        Default = 'ML'.
     **kwargs
         Keyword arguments to pass to the SciPy minimizer.
 
     Notes
     -----
-    The ML and REML solutions are obtained via SciPy's scalar function
-    minimizer (:func:`scipy.optimize.minimize`). Parameters to ``minimize()`` can be
-    passed in as keyword arguments.
+    The ML and REML solutions are obtained via SciPy's scalar function minimizer
+    (:func:`scipy.optimize.minimize`).
+    Parameters to ``minimize()`` can be passed in as keyword arguments.
 
     References
     ----------
-    DerSimonian, R., & Laird, N. (1986). Meta-analysis in clinical trials.
-    Controlled clinical trials, 7(3), 177-188.
-    Kosmidis, I., Guolo, A., & Varin, C. (2017). Improving the accuracy of
-    likelihood-based inference in meta-analysis and meta-regression.
-    Biometrika, 104(2), 489-496. https://doi.org/10.1093/biomet/asx001
+    .. footbibliography::
     """
 
     def __init__(self, method="ml", **kwargs):
@@ -351,31 +345,29 @@ class VarianceBasedLikelihoodEstimator(BaseEstimator):
 class SampleSizeBasedLikelihoodEstimator(BaseEstimator):
     """Likelihood-based estimator for data with known sample sizes but unknown sampling variances.
 
-    Iteratively estimates the between-subject variance tau^2 and fixed effect
-    betas using the specified likelihood-based estimator (ML or REML).
+    Iteratively estimates the between-subject variance tau^2 and fixed effect betas using the
+    specified likelihood-based estimator (ML or REML) :footcite:p:`sangnawakij2019meta`.
 
     Parameters
     ----------
     method : {"ML", "REML"}, optional
-        The estimation method to use. Either 'ML' (for
-        maximum-likelihood) or 'REML' (restricted maximum-likelihood).
-        Defaults to 'ML'.
+        The estimation method to use. Either 'ML' (for maximum-likelihood) or
+        'REML' (restricted maximum-likelihood).
+        Default = 'ML'.
     **kwargs
         Keyword arguments to pass to the SciPy minimizer.
 
     Notes
     -----
-    Homogeneity of sigma^2 across studies is assumed. The ML and REML
-    solutions are obtained via SciPy's scalar function minimizer
-    (scipy.optimize.minimize). Parameters to minimize() can be passed in as
-    keyword arguments.
+    Homogeneity of sigma^2 across studies is assumed.
+
+    The ML and REML solutions are obtained via SciPy's scalar function minimizer
+    (:func:`scipy.optimize.minimize`).
+    Parameters to ``minimize()`` can be passed in as keyword arguments.
 
     References
     ----------
-    Sangnawakij, P., Böhning, D., Niwitpong, S. A., Adams, S., Stanton, M.,
-    & Holling, H. (2019). Meta-analysis without study-specific variance
-    information: Heterogeneity case. Statistical Methods in Medical Research,
-    28(1), 196-210. https://doi.org/10.1177/0962280217718867
+    .. footbibliography::
     """
 
     def __init__(self, method="ml", **kwargs):

--- a/pymare/stats.py
+++ b/pymare/stats.py
@@ -17,7 +17,8 @@ def weighted_least_squares(y, v, X, tau2=0.0, return_cov=False):
     X : :obj:`numpy.ndarray`
         Fixed effect design matrix
     tau2 : :obj:`float`, optional
-        tau^2 estimate to use for weights
+        tau^2 estimate to use for weights.
+        Default = 0.
     return_cov : :obj:`bool`, optional
         Whether or not to return the inverse cov matrix.
         Default = False.
@@ -48,17 +49,20 @@ def ensure_2d(arr):
     """Ensure the passed array has 2 dimensions."""
     if arr is None:
         return arr
+
     try:
         arr = np.array(arr)
     except:
         return arr
+
     if arr.ndim == 1:
         arr = arr[:, None]
+
     return arr
 
 
 def q_profile(y, v, X, alpha=0.05):
-    """Get the CI for tau^2 via the Q-Profile method (Viechtbauer, 2007).
+    """Get the CI for tau^2 via the Q-Profile method.
 
     Parameters
     ----------
@@ -72,7 +76,7 @@ def q_profile(y, v, X, alpha=0.05):
         of studies and P is the number of predictor variables.
     alpha : :obj:`float`, optional
         alpha value defining the coverage of the CIs,
-        where width(CI) = 1 - alpha. Defaults to 0.05.
+        where width(CI) = 1 - alpha. Default = 0.05.
 
     Returns
     -------
@@ -82,16 +86,14 @@ def q_profile(y, v, X, alpha=0.05):
 
     Notes
     -----
-    Following the Viechtbauer implementation, this method returns the
-    interval that gives an equal probability mass at both tails (i.e.,
-    P(tau^2 <= lower_bound)  == P(tau^2 >= upper_bound) == alpha/2), and
-    *not* the smallest possible range of tau^2 values that provides the
-    desired coverage.
+    Following the :footcite:t:`viechtbauer2007confidence` implementation,
+    this method returns the interval that gives an equal probability mass at both tails
+    (i.e., ``P(tau^2 <= lower_bound)  == P(tau^2 >= upper_bound) == alpha/2``),
+    and *not* the smallest possible range of tau^2 values that provides the desired coverage.
 
     References
     ----------
-    Viechtbauer, W. (2007). Confidence intervals for the amount of
-    heterogeneity in meta-analysis. Statistics in Medicine, 26(1), 37-52.
+    .. footbibliography::
     """
     k, p = X.shape
     df = k - p
@@ -114,6 +116,8 @@ def q_profile(y, v, X, alpha=0.05):
 def q_gen(y, v, X, tau2):
     """Calculate a generalized form of Cochran's Q-statistic.
 
+    This version of the Q statistic is described in :footcite:t:`veroniki2016methods`.
+
     Parameters
     ----------
     y : :obj:`numpy.ndarray`
@@ -134,14 +138,11 @@ def q_gen(y, v, X, tau2):
 
     References
     ----------
-    Veroniki, A. A., Jackson, D., Viechtbauer, W., Bender, R., Bowden, J.,
-    Knapp, G., Kuss, O., Higgins, J. P., Langan, D., & Salanti, G. (2016).
-    Methods to estimate the between-study variance and its uncertainty in
-    meta-analysis. Research synthesis methods, 7(1), 55-79.
-    https://doi.org/10.1002/jrsm.1164
+    .. footbibliography::
     """
     if np.any(tau2 < 0):
         raise ValueError("Value of tau^2 must be >= 0.")
+
     beta = weighted_least_squares(y, v, X, tau2)
     w = 1.0 / (v + tau2)
     return (w * (y - X.dot(beta)) ** 2).sum(0)

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,7 @@ doc =
     sphinx-copybutton
     sphinx_gallery==0.10.1
     sphinx_rtd_theme
+    sphinxcontrib-bibtex
 tests =
     codecov
     coverage


### PR DESCRIPTION
Add `sphinxcontrib-bibtex` to documentation requirements and use a BibTeX file to managing references.