### PR TITLE
Make n and X optional for DataFrame-based Datasets

### DIFF
--- a/pymare/core.py
+++ b/pymare/core.py
@@ -71,6 +71,9 @@ class Dataset:
             v = data.loc[:, v or "v"].values
             X_names = X or "X"
             X = data.loc[:, X_names].values
+            # n is optional
+            if (n is not None) or ("n" in data.columns):
+                n = data.loc[:, n or "n"].values
 
         self.y = ensure_2d(y)
         self.v = ensure_2d(v)

--- a/pymare/core.py
+++ b/pymare/core.py
@@ -5,6 +5,8 @@ from functools import partial
 import numpy as np
 import pandas as pd
 
+from pymare.utils import _listify
+
 from .estimators import (
     DerSimonianLaird,
     Hedges,
@@ -65,12 +67,22 @@ class Dataset:
                 "data argument."
             )
 
+        if (X is None) and (not add_intercept):
+            raise ValueError("If no X matrix is provided, add_intercept must be True!")
+
         # Extract columns from DataFrame
         if data is not None:
             y = data.loc[:, y or "y"].values
-            v = data.loc[:, v or "v"].values
-            X_names = X or "X"
-            X = data.loc[:, X_names].values
+
+            # v is optional
+            if (v is not None) or ("v" in data.columns):
+                v = data.loc[:, v or "v"].values
+
+            # X is optional
+            if (X is not None) or ("X" in data.columns):
+                X_names = X or "X"
+                X = data.loc[:, X_names].values
+
             # n is optional
             if (n is not None) or ("n" in data.columns):
                 n = data.loc[:, n or "n"].values
@@ -88,12 +100,15 @@ class Dataset:
                 "No fixed predictors found. If no X matrix is "
                 "provided, add_intercept must be True!"
             )
+
         X = pd.DataFrame(X)
         if names is not None:
-            X.columns = names
+            X.columns = _listify(names)
+
         if add_intercept:
             intercept = pd.DataFrame({"intercept": np.ones(len(self.y))})
             X = pd.concat([intercept, X], axis=1)
+
         return X.values, X.columns.tolist()
 
 

--- a/pymare/utils.py
+++ b/pymare/utils.py
@@ -1,0 +1,10 @@
+"""Miscellaneous utility functions."""
+import numpy as np
+
+
+def _listify(obj):
+    """Wrap all non-list or tuple objects in a list.
+
+    This provides a simple way to accept flexible arguments.
+    """
+    return obj if isinstance(obj, (list, tuple, type(None), np.ndarray)) else [obj]


### PR DESCRIPTION
Closes #88.

Changes proposed:
- Allow `n` with DataFrame-based Datasets.
- Make `X` optional for Datasets.
- Improve the associated test.