### PR TITLE
Coerce tau2 to an array in permutation_test

### DIFF
--- a/examples/02_meta-analysis/plot_run_meta-analysis.py
+++ b/examples/02_meta-analysis/plot_run_meta-analysis.py
@@ -46,6 +46,10 @@ pprint(results.get_heterogeneity_stats())
 pprint(results.get_re_stats())
 
 ###############################################################################
+perm_results = results.permutation_test(n_perm=1000)
+perm_results.to_df()
+
+###############################################################################
 # References
 # -----------------------------------------------------------------------------
 # .. footbibliography::

--- a/examples/02_meta-analysis/plot_run_meta-analysis.py
+++ b/examples/02_meta-analysis/plot_run_meta-analysis.py
@@ -31,6 +31,14 @@ dset.to_df()
 ###############################################################################
 # Now we fit a model
 # -----------------------------------------------------------------------------
+# You must first initialize the estimator, after which you can use
+# :func:`~pymare.estimators.fit` to fit the model to numpy arrays, or
+# :func:`~pymare.estimators.fit_dataset` to fit it to a
+# :class:`~pymare.core.Dataset`.
+#
+# The :func:`~pymare.estimators.summary` function will return a
+# :class:`~pymare.results.MetaRegressionResults` object, which contains the
+# results of the analysis.
 est = estimators.WeightedLeastSquares().fit_dataset(dset)
 results = est.summary()
 results.to_df()
@@ -38,14 +46,18 @@ results.to_df()
 ###############################################################################
 # We can also extract some useful information from the results object
 # -----------------------------------------------------------------------------
-# Here we'll take a look at the heterogeneity statistics.
+# The :meth:`~pymare.results.MetaRegressionResults.get_heterogeneity_stats`
+# method will calculate heterogeneity statistics.
 pprint(results.get_heterogeneity_stats())
 
 ###############################################################################
-# We can also estimate the confidence interval for :math:`\tau^2`.
+# The :meth:`~pymare.results.MetaRegressionResults.get_re_stats` method will
+# estimate the confidence interval for :math:`\tau^2`.
 pprint(results.get_re_stats())
 
 ###############################################################################
+# The :meth:`~pymare.results.MetaRegressionResults.permutation_test` method
+# will run a permutation test to estimate more accurate p-values.
 perm_results = results.permutation_test(n_perm=1000)
 perm_results.to_df()
 

--- a/examples/02_meta-analysis/plot_run_meta-analysis.py
+++ b/examples/02_meta-analysis/plot_run_meta-analysis.py
@@ -32,11 +32,11 @@ dset.to_df()
 # Now we fit a model
 # -----------------------------------------------------------------------------
 # You must first initialize the estimator, after which you can use
-# :func:`~pymare.estimators.fit` to fit the model to numpy arrays, or
-# :func:`~pymare.estimators.fit_dataset` to fit it to a
+# :meth:`~pymare.estimators.BaseEstimator.fit` to fit the model to numpy arrays,
+# or :meth:`~pymare.estimators.BaseEstimator.fit_dataset` to fit it to a
 # :class:`~pymare.core.Dataset`.
 #
-# The :func:`~pymare.estimators.summary` function will return a
+# The :meth:`~pymare.estimators.BaseEstimator.summary` function will return a
 # :class:`~pymare.results.MetaRegressionResults` object, which contains the
 # results of the analysis.
 est = estimators.WeightedLeastSquares().fit_dataset(dset)

--- a/examples/02_meta-analysis/plot_run_meta-analysis.py
+++ b/examples/02_meta-analysis/plot_run_meta-analysis.py
@@ -32,13 +32,14 @@ dset.to_df()
 # Now we fit a model
 # -----------------------------------------------------------------------------
 # You must first initialize the estimator, after which you can use
-# :meth:`~pymare.estimators.BaseEstimator.fit` to fit the model to numpy arrays,
-# or :meth:`~pymare.estimators.BaseEstimator.fit_dataset` to fit it to a
-# :class:`~pymare.core.Dataset`.
+# :meth:`~pymare.estimators.estimators.BaseEstimator.fit` to fit the model to
+# numpy arrays, or
+# :meth:`~pymare.estimators.estimators.BaseEstimator.fit_dataset` to fit it to
+# a :class:`~pymare.core.Dataset`.
 #
-# The :meth:`~pymare.estimators.BaseEstimator.summary` function will return a
-# :class:`~pymare.results.MetaRegressionResults` object, which contains the
-# results of the analysis.
+# The :meth:`~pymare.estimators.estimators.BaseEstimator.summary` function
+# will return a :class:`~pymare.results.MetaRegressionResults` object,
+# which contains the results of the analysis.
 est = estimators.WeightedLeastSquares().fit_dataset(dset)
 results = est.summary()
 results.to_df()


### PR DESCRIPTION
Closes None, but should fix a bug when running `permutation_test` on `WeightedLeastSquares` results, since WLS has a single tau2 value across all datasets.

Changes proposed:

- Ensure that tau2 is an array within `permutation_test`, so that it doesn't fail on 1D Datasets.
- Use `MetaRegressionResults.permutation_test()` in an example.