### PR TITLE
Fix maximum likelihood Estimators' SE outputs

### DIFF
--- a/pymare/results.py
+++ b/pymare/results.py
@@ -47,7 +47,10 @@ class MetaRegressionResults:
     @lru_cache(maxsize=1)
     def fe_se(self):
         """Get fixed-effect standard error."""
-        cov = np.atleast_3d(self.fe_cov)  # 3rd dim is for parallel datasets
+        cov = self.fe_cov.copy()
+        if cov.ndim == 2:
+            cov = cov[None, :, :]
+
         return np.sqrt(np.diagonal(cov)).T
 
     @lru_cache(maxsize=16)

--- a/pymare/tests/test_estimators.py
+++ b/pymare/tests/test_estimators.py
@@ -18,6 +18,19 @@ def test_weighted_least_squares_estimator(dataset):
     est = WeightedLeastSquares().fit_dataset(dataset)
     results = est.summary()
     beta, tau2 = results.fe_params, results.tau2
+    fe_stats = results.get_fe_stats()
+
+    # Check output shapes
+    assert beta.shape == (2, 1)
+    assert isinstance(tau2, float)
+    assert fe_stats["est"].shape == (2, 1)
+    assert fe_stats["se"].shape == (2, 1)
+    assert fe_stats["ci_l"].shape == (2, 1)
+    assert fe_stats["ci_u"].shape == (2, 1)
+    assert fe_stats["z"].shape == (2, 1)
+    assert fe_stats["p"].shape == (2, 1)
+
+    # Check output values
     assert np.allclose(beta.ravel(), [-0.2725, 0.6935], atol=1e-4)
     assert tau2 == 0.0
 
@@ -35,6 +48,19 @@ def test_dersimonian_laird_estimator(dataset):
     est = DerSimonianLaird().fit_dataset(dataset)
     results = est.summary()
     beta, tau2 = results.fe_params, results.tau2
+    fe_stats = results.get_fe_stats()
+
+    # Check output shapes
+    assert beta.shape == (2, 1)
+    assert tau2.shape == (1,)
+    assert fe_stats["est"].shape == (2, 1)
+    assert fe_stats["se"].shape == (2, 1)
+    assert fe_stats["ci_l"].shape == (2, 1)
+    assert fe_stats["ci_u"].shape == (2, 1)
+    assert fe_stats["z"].shape == (2, 1)
+    assert fe_stats["p"].shape == (2, 1)
+
+    # Check output values
     assert np.allclose(beta.ravel(), [-0.1070, 0.7664], atol=1e-4)
     assert np.allclose(tau2, 8.3627, atol=1e-4)
 
@@ -43,9 +69,19 @@ def test_2d_DL_estimator(dataset_2d):
     """Test DerSimonianLaird estimator on 2D Dataset."""
     results = DerSimonianLaird().fit_dataset(dataset_2d).summary()
     beta, tau2 = results.fe_params, results.tau2
+    fe_stats = results.get_fe_stats()
+
+    # Check output shapes
     assert beta.shape == (2, 3)
     assert tau2.shape == (3,)
+    assert fe_stats["est"].shape == (2, 3)
+    assert fe_stats["se"].shape == (2, 3)
+    assert fe_stats["ci_l"].shape == (2, 3)
+    assert fe_stats["ci_u"].shape == (2, 3)
+    assert fe_stats["z"].shape == (2, 3)
+    assert fe_stats["p"].shape == (2, 3)
 
+    # Check output values
     # First and third sets are identical to previous DL test; second set is
     # randomly different.
     assert np.allclose(beta[:, 0], [-0.1070, 0.7664], atol=1e-4)
@@ -64,6 +100,19 @@ def test_hedges_estimator(dataset):
     est = Hedges().fit_dataset(dataset)
     results = est.summary()
     beta, tau2 = results.fe_params, results.tau2
+    fe_stats = results.get_fe_stats()
+
+    # Check output shapes
+    assert beta.shape == (2, 1)
+    assert tau2.shape == (1,)
+    assert fe_stats["est"].shape == (2, 1)
+    assert fe_stats["se"].shape == (2, 1)
+    assert fe_stats["ci_l"].shape == (2, 1)
+    assert fe_stats["ci_u"].shape == (2, 1)
+    assert fe_stats["z"].shape == (2, 1)
+    assert fe_stats["p"].shape == (2, 1)
+
+    # Check output values
     assert np.allclose(beta.ravel(), [-0.1066, 0.7704], atol=1e-4)
     assert np.allclose(tau2, 11.3881, atol=1e-4)
 
@@ -72,8 +121,17 @@ def test_2d_hedges(dataset_2d):
     """Test Hedges estimator on 2D Dataset."""
     results = Hedges().fit_dataset(dataset_2d).summary()
     beta, tau2 = results.fe_params, results.tau2
+    fe_stats = results.get_fe_stats()
+
+    # Check output shapes
     assert beta.shape == (2, 3)
     assert tau2.shape == (3,)
+    assert fe_stats["est"].shape == (2, 3)
+    assert fe_stats["se"].shape == (2, 3)
+    assert fe_stats["ci_l"].shape == (2, 3)
+    assert fe_stats["ci_u"].shape == (2, 3)
+    assert fe_stats["z"].shape == (2, 3)
+    assert fe_stats["p"].shape == (2, 3)
 
     # First and third sets are identical to single dim test; second set is
     # randomly different.
@@ -91,6 +149,19 @@ def test_variance_based_maximum_likelihood_estimator(dataset):
     est = VarianceBasedLikelihoodEstimator(method="ML").fit_dataset(dataset)
     results = est.summary()
     beta, tau2 = results.fe_params, results.tau2
+    fe_stats = results.get_fe_stats()
+
+    # Check output shapes
+    assert beta.shape == (2, 1)
+    assert tau2.shape == (1, 1)
+    assert fe_stats["est"].shape == (2, 1)
+    assert fe_stats["se"].shape == (2, 1)
+    assert fe_stats["ci_l"].shape == (2, 1)
+    assert fe_stats["ci_u"].shape == (2, 1)
+    assert fe_stats["z"].shape == (2, 1)
+    assert fe_stats["p"].shape == (2, 1)
+
+    # Check output values
     assert np.allclose(beta.ravel(), [-0.1072, 0.7653], atol=1e-4)
     assert np.allclose(tau2, 7.7649, atol=1e-4)
 
@@ -101,6 +172,19 @@ def test_variance_based_restricted_maximum_likelihood_estimator(dataset):
     est = VarianceBasedLikelihoodEstimator(method="REML").fit_dataset(dataset)
     results = est.summary()
     beta, tau2 = results.fe_params, results.tau2
+    fe_stats = results.get_fe_stats()
+
+    # Check output shapes
+    assert beta.shape == (2, 1)
+    assert tau2.shape == (1, 1)
+    assert fe_stats["est"].shape == (2, 1)
+    assert fe_stats["se"].shape == (2, 1)
+    assert fe_stats["ci_l"].shape == (2, 1)
+    assert fe_stats["ci_u"].shape == (2, 1)
+    assert fe_stats["z"].shape == (2, 1)
+    assert fe_stats["p"].shape == (2, 1)
+
+    # Check output values
     assert np.allclose(beta.ravel(), [-0.1066, 0.7700], atol=1e-4)
     assert np.allclose(tau2, 10.9499, atol=1e-4)
 
@@ -113,6 +197,20 @@ def test_sample_size_based_maximum_likelihood_estimator(dataset_n):
     beta = results.fe_params
     sigma2 = results.estimator.params_["sigma2"]
     tau2 = results.tau2
+    fe_stats = results.get_fe_stats()
+
+    # Check output shapes
+    assert beta.shape == (1, 1)
+    assert sigma2.shape == (1, 1)
+    assert tau2.shape == (1, 1)
+    assert fe_stats["est"].shape == (1, 1)
+    assert fe_stats["se"].shape == (1, 1)
+    assert fe_stats["ci_l"].shape == (1, 1)
+    assert fe_stats["ci_u"].shape == (1, 1)
+    assert fe_stats["z"].shape == (1, 1)
+    assert fe_stats["p"].shape == (1, 1)
+
+    # Check output values
     assert np.allclose(beta, [-2.0951], atol=1e-4)
     assert np.allclose(sigma2, 12.777, atol=1e-3)
     assert np.allclose(tau2, 2.8268, atol=1e-4)
@@ -126,6 +224,20 @@ def test_sample_size_based_restricted_maximum_likelihood_estimator(dataset_n):
     beta = results.fe_params
     sigma2 = results.estimator.params_["sigma2"]
     tau2 = results.tau2
+    fe_stats = results.get_fe_stats()
+
+    # Check output shapes
+    assert beta.shape == (1, 1)
+    assert sigma2.shape == (1, 1)
+    assert tau2.shape == (1, 1)
+    assert fe_stats["est"].shape == (1, 1)
+    assert fe_stats["se"].shape == (1, 1)
+    assert fe_stats["ci_l"].shape == (1, 1)
+    assert fe_stats["ci_u"].shape == (1, 1)
+    assert fe_stats["z"].shape == (1, 1)
+    assert fe_stats["p"].shape == (1, 1)
+
+    # Check output values
     assert np.allclose(beta, [-2.1071], atol=1e-4)
     assert np.allclose(sigma2, 13.048, atol=1e-3)
     assert np.allclose(tau2, 3.2177, atol=1e-4)
@@ -136,9 +248,19 @@ def test_2d_looping(dataset_2d):
     est = VarianceBasedLikelihoodEstimator().fit_dataset(dataset_2d)
     results = est.summary()
     beta, tau2 = results.fe_params, results.tau2
+    fe_stats = results.get_fe_stats()
+
+    # Check output shapes
     assert beta.shape == (2, 3)
     assert tau2.shape == (1, 3)
+    assert fe_stats["est"].shape == (2, 3)
+    assert fe_stats["se"].shape == (2, 3)
+    assert fe_stats["ci_l"].shape == (2, 3)
+    assert fe_stats["ci_u"].shape == (2, 3)
+    assert fe_stats["z"].shape == (2, 3)
+    assert fe_stats["p"].shape == (2, 3)
 
+    # Check output values
     # First and third sets are identical to single dim test; 2nd is different
     assert np.allclose(beta[:, 0], [-0.1072, 0.7653], atol=1e-4)
     assert np.allclose(tau2[0, 0], 7.7649, atol=1e-4)


### PR DESCRIPTION
Closes #97.

Changes proposed:

- Make covariance matrix 3D in the right shape (`n_regressors`, `n_regressors`, `n_datasets`) instead of  (`n_regressors`, `n_datasets`, `n_regressors`).
- Test variable shapes in all Estimator tests.