### PR TITLE
Add shape check to Dataset initialization

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -11,6 +11,11 @@
       "orcid": "0000-0001-9813-3167"
     },
     {
+      "name": "Peraza, Julio A.",
+      "affiliation": "Florida International University",
+      "orcid": "0000-0003-3816-5903"
+    },
+    {
       "name": "Nichols, Thomas E.",
       "affiliation": "Big Data Institute, University of Oxford",
       "orcid": "0000-0002-4516-5103"

--- a/pymare/core.py
+++ b/pymare/core.py
@@ -5,7 +5,7 @@ from functools import partial
 import numpy as np
 import pandas as pd
 
-from pymare.utils import _listify
+from pymare.utils import _check_inputs_shape, _listify
 
 from .estimators import (
     DerSimonianLaird,
@@ -93,6 +93,10 @@ class Dataset:
         X, names = self._get_predictors(X, X_names, add_intercept)
         self.X = X
         self.X_names = names
+
+        _check_inputs_shape(self.y, self.X, "y", "X", row=True)
+        _check_inputs_shape(self.y, self.v, "y", "v", row=True, column=True)
+        _check_inputs_shape(self.y, self.n, "y", "n", row=True, column=True)
 
     def _get_predictors(self, X, names, add_intercept):
         if X is None and not add_intercept:

--- a/pymare/tests/test_utils.py
+++ b/pymare/tests/test_utils.py
@@ -35,3 +35,6 @@ def test_check_inputs_shape():
     # Raise error if neither row or column is True
     with pytest.raises(ValueError):
         utils._check_inputs_shape(y, n, "y", "n")
+
+    # Dataset may be initialized with n or v as None
+    utils._check_inputs_shape(y, None, "y", "n", row=True, column=True)

--- a/pymare/tests/test_utils.py
+++ b/pymare/tests/test_utils.py
@@ -1,6 +1,8 @@
 """Tests for pymare.utils."""
 import os.path as op
 
+import numpy as np
+
 from pymare import utils
 
 
@@ -8,3 +10,20 @@ def test_get_resource_path():
     """Test nimare.utils.get_resource_path."""
     print(utils.get_resource_path())
     assert op.isdir(utils.get_resource_path())
+
+
+def test_check_inputs_shape():
+    """Test nimare.utils._check_inputs_shape."""
+    n_rows = 5
+    n_columns = 4
+    n_pred = 3
+    y = np.random.randint(1, 100, size=(n_rows, n_columns))
+    v = np.random.randint(1, 100, size=(n_rows, n_columns))
+    n = np.random.randint(1, 100, size=(n_rows, n_columns))
+    X = np.random.randint(1, 100, size=(n_rows, n_pred))
+    X_names = [f"X{x}" for x in range(n_pred)]
+
+    utils._check_inputs_shape(y, X, "y", "X", row=True)
+    utils._check_inputs_shape(y, v, "y", "v", row=True, column=True)
+    utils._check_inputs_shape(y, n, "y", "n", row=True, column=True)
+    utils._check_inputs_shape(X, np.array(X_names)[None, :], "X", "X_names", column=True)

--- a/pymare/tests/test_utils.py
+++ b/pymare/tests/test_utils.py
@@ -2,6 +2,7 @@
 import os.path as op
 
 import numpy as np
+import pytest
 
 from pymare import utils
 
@@ -18,12 +19,19 @@ def test_check_inputs_shape():
     n_columns = 4
     n_pred = 3
     y = np.random.randint(1, 100, size=(n_rows, n_columns))
-    v = np.random.randint(1, 100, size=(n_rows, n_columns))
+    v = np.random.randint(1, 100, size=(n_rows + 1, n_columns))
     n = np.random.randint(1, 100, size=(n_rows, n_columns))
     X = np.random.randint(1, 100, size=(n_rows, n_pred))
     X_names = [f"X{x}" for x in range(n_pred)]
 
     utils._check_inputs_shape(y, X, "y", "X", row=True)
-    utils._check_inputs_shape(y, v, "y", "v", row=True, column=True)
     utils._check_inputs_shape(y, n, "y", "n", row=True, column=True)
     utils._check_inputs_shape(X, np.array(X_names)[None, :], "X", "X_names", column=True)
+
+    # Raise error if the number of rows and columns of v don't match y
+    with pytest.raises(ValueError):
+        utils._check_inputs_shape(y, v, "y", "v", row=True, column=True)
+
+    # Raise error if neither row or column is True
+    with pytest.raises(ValueError):
+        utils._check_inputs_shape(y, n, "y", "n")

--- a/pymare/utils.py
+++ b/pymare/utils.py
@@ -55,6 +55,3 @@ def _check_inputs_shape(param1, param2, param1_name, param2_name, row=False, col
                 f"You provided {param1_name} with shape {param1.shape} and {param2_name} "
                 f"with shape {param2.shape}."
             )
-    elif (param1 is None) or (param2 is None):
-        # If param1 or param2 is None, we don't need to check the shape
-        pass

--- a/pymare/utils.py
+++ b/pymare/utils.py
@@ -55,3 +55,6 @@ def _check_inputs_shape(param1, param2, param1_name, param2_name, row=False, col
                 f"You provided {param1_name} with shape {param1.shape} and {param2_name} "
                 f"with shape {param2.shape}."
             )
+    elif (param1 is None) or (param2 is None):
+        # If param1 or param2 is None, we don't need to check the shape
+        pass

--- a/pymare/utils.py
+++ b/pymare/utils.py
@@ -19,3 +19,39 @@ def _listify(obj):
     This provides a simple way to accept flexible arguments.
     """
     return obj if isinstance(obj, (list, tuple, type(None), np.ndarray)) else [obj]
+
+
+def _check_inputs_shape(param1, param2, param1_name, param2_name, row=False, column=False):
+    """Check whether 'param1' and 'param2' have the same shape.
+
+    Parameters
+    ----------
+    param1 : array
+    param2 : array
+    param1_name : str
+    param2_name : str
+    row : bool, default to False.
+    column : bool, default to False.
+    """
+    if (param1 is not None) and (param2 is not None):
+        if row and not column:
+            shape1 = param1.shape[0]
+            shape2 = param2.shape[0]
+            message = "rows"
+        elif column and not row:
+            shape1 = param1.shape[1]
+            shape2 = param2.shape[1]
+            message = "columns"
+        elif row and column:
+            shape1 = param1.shape
+            shape2 = param2.shape
+            message = "rows and columns"
+        else:
+            raise ValueError("At least one of the two parameters (row or column) should be True.")
+
+        if shape1 != shape2:
+            raise ValueError(
+                f"{param1_name} and {param2_name} should have the same number of {message}. "
+                f"You provided {param1_name} with shape {param1.shape} and {param2_name} "
+                f"with shape {param2.shape}."
+            )


### PR DESCRIPTION
Closes #99.

Changes proposed in this pull request: 
- Add `_check_inputs_shape()` function to `utils.py` to avoid repetitive code.
- Add shape check to Dataset initialization: 
    - Check whether the number of rows of `y` matches `X`.
    - Check whether the number of rows and columns of `y` match `v`.
    - Check whether the number of rows and columns of `y` match `n`.

**Note:** I didn't check for the number of columns of `X` vs the length of `X_names`, because an exception is raised in case of any mismatch when `_get_predictors()` is applied.