### PR TITLE
Use 1D array in `scipy.optimize.minimize`

### DIFF
--- a/pymare/stats.py
+++ b/pymare/stats.py
@@ -109,7 +109,7 @@ def q_profile(y, v, X, alpha=0.05):
     ub_start = 2 * DerSimonianLaird().fit(y, v, X).params_["tau2"]
 
     lb = minimize(lambda x: (q_gen(*args, x) - l_crit) ** 2, [0], bounds=bds).x[0]
-    ub = minimize(lambda x: (q_gen(*args, x) - u_crit) ** 2, [ub_start], bounds=bds).x[0]
+    ub = minimize(lambda x: (q_gen(*args, x) - u_crit) ** 2, ub_start, bounds=bds).x[0]
     return {"ci_l": lb, "ci_u": ub}
 
 


### PR DESCRIPTION
Closes #109.

In the latest scipy release, the use of `minimize` with `x0.ndim != 1` is being deprecated. 

Currently, the output of `ub_start = 2 * DerSimonianLaird().fit(y, v, X).params_["tau2"]` is already a 1D array so the use of `minimize` with `[ub_start]` gives `x0.ndim = 2`, which then gets converted to an array of dimension 0 by `np.squeeze(x0)`, resulting in an error here:
https://github.com/scipy/scipy/blob/903bc39809af20a1447ed702e84592397c3de509/scipy/optimize/_minimize.py#L947

Changes proposed in this pull request:

- Remove square brackets from `ub_start` in `minimize`.