### PR TITLE
Merged `fit()` and `fit_dataset()`. Replace `summary()` with `transform()`. Add `fit_transform()`.

### DIFF
--- a/pymare/core.py
+++ b/pymare/core.py
@@ -260,5 +260,4 @@ def meta_regression(
 
     # Get estimates
     est = est_cls(**kwargs)
-    est.fit_dataset(data)
-    return est.summary()
+    return est.fit_transform(data)

--- a/pymare/estimators/combination.py
+++ b/pymare/estimators/combination.py
@@ -34,7 +34,7 @@ class CombinationTest(BaseEstimator):
     def _z_to_p(self, z):
         return ss.norm.sf(z)
 
-    def fit(self, z, *args, **kwargs):
+    def _fit(self, z, *args, **kwargs):
         """Fit the estimator to z-values."""
         # This resets the Estimator's dataset_ attribute. fit_dataset will overwrite if called.
         self.dataset_ = None
@@ -51,13 +51,13 @@ class CombinationTest(BaseEstimator):
         self.params_ = {"p": p}
         return self
 
-    def summary(self):
-        """Generate a summary of the estimator results."""
+    def transform(self):
+        """Generate a transform of the estimator results."""
         if not hasattr(self, "params_"):
             name = self.__class__.__name__
             raise ValueError(
                 "This {} instance hasn't been fitted yet. Please "
-                "call fit() before summary().".format(name)
+                "call _fit() of fit() before transform().".format(name)
             )
         return CombinationTestResults(self, self.dataset_, p=self.params_["p"])
 
@@ -112,9 +112,9 @@ class StoufferCombinationTest(CombinationTest):
     # Maps Dataset attributes onto fit() args; see BaseEstimator for details.
     _dataset_attr_map = {"z": "y", "w": "v"}
 
-    def fit(self, z, w=None):
+    def _fit(self, z, w=None):
         """Fit the estimator to z-values, optionally with weights."""
-        return super().fit(z, w=w)
+        return super()._fit(z, w=w)
 
     def p_value(self, z, w=None):
         """Calculate p-values."""

--- a/pymare/results.py
+++ b/pymare/results.py
@@ -37,7 +37,7 @@ class MetaRegressionResults:
 
     Warning
     -------
-    When an Estimator is fitted to arrays directly using the ``fit`` method, the Results object's
+    When an Estimator is fitted to arrays directly using the ``_fit`` method, the Results object's
     utility is limited.
     Many methods will not work.
     """
@@ -336,7 +336,7 @@ class MetaRegressionResults:
             y_perm = np.repeat(y[:, None], n_perm, axis=1)
 
             # for v, we might actually be working with n, depending on estimator
-            has_v = "v" in getfullargspec(self.estimator.fit).args[1:]
+            has_v = "v" in getfullargspec(self.estimator._fit).args[1:]
             v = self.dataset.v[:, i] if has_v else self.dataset.n[:, i]
 
             v_perm = np.repeat(v[:, None], n_perm, axis=1)
@@ -362,7 +362,7 @@ class MetaRegressionResults:
             # Pass parameters, remembering that v may actually be n
             kwargs = {"y": y_perm, "X": self.dataset.X}
             kwargs["v" if has_v else "n"] = v_perm
-            params = self.estimator.fit(**kwargs).params_
+            params = self.estimator._fit(**kwargs).params_
 
             fe_obs = fe_stats["est"][:, i]
             if fe_obs.ndim == 1:
@@ -483,9 +483,9 @@ class CombinationTestResults:
 
             # Some combination tests can handle weights (passed as v)
             kwargs = {"z": y_perm}
-            if "w" in getfullargspec(est.fit).args:
+            if "w" in getfullargspec(est._fit).args:
                 kwargs["w"] = self.dataset.v
-            params = est.fit(**kwargs).params_
+            params = est._fit(**kwargs).params_
 
             p_obs = self.z[i]
             if p_obs.ndim == 1:

--- a/pymare/stats.py
+++ b/pymare/stats.py
@@ -106,7 +106,7 @@ def q_profile(y, v, X, alpha=0.05):
     # value, minimize() sometimes fails to stay in bounds.
     from .estimators import DerSimonianLaird
 
-    ub_start = 2 * DerSimonianLaird().fit(y, v, X).params_["tau2"]
+    ub_start = 2 * DerSimonianLaird()._fit(y, v, X).params_["tau2"]
 
     lb = minimize(lambda x: (q_gen(*args, x) - l_crit) ** 2, [0], bounds=bds).x[0]
     ub = minimize(lambda x: (q_gen(*args, x) - u_crit) ** 2, ub_start, bounds=bds).x[0]

--- a/pymare/tests/test_combination_tests.py
+++ b/pymare/tests/test_combination_tests.py
@@ -28,7 +28,7 @@ _params = [
 @pytest.mark.parametrize("Cls,data,mode,expected", _params)
 def test_combination_test(Cls, data, mode, expected):
     """Test CombinationTest Estimators with numpy data."""
-    results = Cls(mode).fit(data).params_
+    results = Cls(mode)._fit(data).params_
     z = ss.norm.isf(results["p"])
     assert np.allclose(z, expected, atol=1e-5)
 
@@ -37,7 +37,7 @@ def test_combination_test(Cls, data, mode, expected):
 def test_combination_test_from_dataset(Cls, data, mode, expected):
     """Test CombinationTest Estimators with PyMARE Datasets."""
     dset = Dataset(y=data)
-    est = Cls(mode).fit_dataset(dset)
-    results = est.summary()
+    est = Cls(mode).fit(dset)
+    results = est.transform()
     z = ss.norm.isf(results.p)
     assert np.allclose(z, expected, atol=1e-5)

--- a/pymare/tests/test_estimators.py
+++ b/pymare/tests/test_estimators.py
@@ -15,8 +15,8 @@ from pymare.estimators import (
 def test_weighted_least_squares_estimator(dataset):
     """Test WeightedLeastSquares estimator."""
     # ground truth values are from metafor package in R
-    est = WeightedLeastSquares().fit_dataset(dataset)
-    results = est.summary()
+    est = WeightedLeastSquares().fit(dataset)
+    results = est.transform()
     beta, tau2 = results.fe_params, results.tau2
     fe_stats = results.get_fe_stats()
 
@@ -35,8 +35,8 @@ def test_weighted_least_squares_estimator(dataset):
     assert tau2 == 0.0
 
     # With non-zero tau^2
-    est = WeightedLeastSquares(8.0).fit_dataset(dataset)
-    results = est.summary()
+    est = WeightedLeastSquares(8.0).fit(dataset)
+    results = est.transform()
     beta, tau2 = results.fe_params, results.tau2
     assert np.allclose(beta.ravel(), [-0.1071, 0.7657], atol=1e-4)
     assert tau2 == 8.0
@@ -45,8 +45,8 @@ def test_weighted_least_squares_estimator(dataset):
 def test_dersimonian_laird_estimator(dataset):
     """Test DerSimonianLaird estimator."""
     # ground truth values are from metafor package in R
-    est = DerSimonianLaird().fit_dataset(dataset)
-    results = est.summary()
+    est = DerSimonianLaird().fit(dataset)
+    results = est.transform()
     beta, tau2 = results.fe_params, results.tau2
     fe_stats = results.get_fe_stats()
 
@@ -67,7 +67,8 @@ def test_dersimonian_laird_estimator(dataset):
 
 def test_2d_DL_estimator(dataset_2d):
     """Test DerSimonianLaird estimator on 2D Dataset."""
-    results = DerSimonianLaird().fit_dataset(dataset_2d).summary()
+    est = DerSimonianLaird().fit(dataset_2d)
+    results = est.transform()
     beta, tau2 = results.fe_params, results.tau2
     fe_stats = results.get_fe_stats()
 
@@ -97,8 +98,8 @@ def test_hedges_estimator(dataset):
     # ground truth values are from metafor package in R, except that metafor
     # always gives negligibly different values for tau2, likely due to
     # algorithmic differences in the computation.
-    est = Hedges().fit_dataset(dataset)
-    results = est.summary()
+    est = Hedges().fit(dataset)
+    results = est.transform()
     beta, tau2 = results.fe_params, results.tau2
     fe_stats = results.get_fe_stats()
 
@@ -119,7 +120,8 @@ def test_hedges_estimator(dataset):
 
 def test_2d_hedges(dataset_2d):
     """Test Hedges estimator on 2D Dataset."""
-    results = Hedges().fit_dataset(dataset_2d).summary()
+    est = Hedges().fit(dataset_2d)
+    results = est.transform()
     beta, tau2 = results.fe_params, results.tau2
     fe_stats = results.get_fe_stats()
 
@@ -146,8 +148,8 @@ def test_2d_hedges(dataset_2d):
 def test_variance_based_maximum_likelihood_estimator(dataset):
     """Test VarianceBasedLikelihoodEstimator estimator."""
     # ground truth values are from metafor package in R
-    est = VarianceBasedLikelihoodEstimator(method="ML").fit_dataset(dataset)
-    results = est.summary()
+    est = VarianceBasedLikelihoodEstimator(method="ML").fit(dataset)
+    results = est.transform()
     beta, tau2 = results.fe_params, results.tau2
     fe_stats = results.get_fe_stats()
 
@@ -169,8 +171,8 @@ def test_variance_based_maximum_likelihood_estimator(dataset):
 def test_variance_based_restricted_maximum_likelihood_estimator(dataset):
     """Test VarianceBasedLikelihoodEstimator estimator with REML."""
     # ground truth values are from metafor package in R
-    est = VarianceBasedLikelihoodEstimator(method="REML").fit_dataset(dataset)
-    results = est.summary()
+    est = VarianceBasedLikelihoodEstimator(method="REML").fit(dataset)
+    results = est.transform()
     beta, tau2 = results.fe_params, results.tau2
     fe_stats = results.get_fe_stats()
 
@@ -192,8 +194,8 @@ def test_variance_based_restricted_maximum_likelihood_estimator(dataset):
 def test_sample_size_based_maximum_likelihood_estimator(dataset_n):
     """Test SampleSizeBasedLikelihoodEstimator estimator."""
     # test values have not been verified for convergence with other packages
-    est = SampleSizeBasedLikelihoodEstimator(method="ML").fit_dataset(dataset_n)
-    results = est.summary()
+    est = SampleSizeBasedLikelihoodEstimator(method="ML").fit(dataset_n)
+    results = est.transform()
     beta = results.fe_params
     sigma2 = results.estimator.params_["sigma2"]
     tau2 = results.tau2
@@ -219,8 +221,8 @@ def test_sample_size_based_maximum_likelihood_estimator(dataset_n):
 def test_sample_size_based_restricted_maximum_likelihood_estimator(dataset_n):
     """Test SampleSizeBasedLikelihoodEstimator REML estimator."""
     # test values have not been verified for convergence with other packages
-    est = SampleSizeBasedLikelihoodEstimator(method="REML").fit_dataset(dataset_n)
-    results = est.summary()
+    est = SampleSizeBasedLikelihoodEstimator(method="REML").fit(dataset_n)
+    results = est.transform()
     beta = results.fe_params
     sigma2 = results.estimator.params_["sigma2"]
     tau2 = results.tau2
@@ -245,8 +247,8 @@ def test_sample_size_based_restricted_maximum_likelihood_estimator(dataset_n):
 
 def test_2d_looping(dataset_2d):
     """Test 2D looping in estimators."""
-    est = VarianceBasedLikelihoodEstimator().fit_dataset(dataset_2d)
-    results = est.summary()
+    est = VarianceBasedLikelihoodEstimator().fit(dataset_2d)
+    results = est.transform()
     beta, tau2 = results.fe_params, results.tau2
     fe_stats = results.get_fe_stats()
 
@@ -278,6 +280,6 @@ def test_2d_loop_warning(dataset_2d):
     dataset = Dataset(y, v)
     # Warning is raised when 2nd dim is > 10
     with pytest.warns(UserWarning, match="Input contains"):
-        est.fit_dataset(dataset)
+        est.fit(dataset)
     # But not when it's smaller
-    est.fit_dataset(dataset_2d)
+    est.fit(dataset_2d)


### PR DESCRIPTION
Closes #103.

Changes proposed in this pull request:
- Merged `fit()` and `fit_dataset()` in BaseEstimator.
- Add `fit_transform()` in BaseEstimator, to fit and transform data in one step. 
- Convert `fit()` to `_fit()` for all estimators.
- Make CombinationTest compatible with BaseEstimator.
- Add `test_estimator_fit_transform`.