### PR TITLE
Raise deprecation warnings with Python 3.6 and 3.7

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,9 +7,6 @@ on:
   pull_request:
     branches:
       - '*'
-  schedule:
-    # Run tests every Sunday at 12am
-    - cron: '0 0 * * 0'
 
 concurrency:
   group: environment-${{ github.ref }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -40,6 +40,14 @@ jobs:
         matrix:
             os: ["ubuntu-latest", "macos-latest"]
             python-version: ["3.6", "3.7", "3.8", "3.9"]
+            include:
+              # ubuntu-20.04 is used only to test python 3.6
+              - os: "ubuntu-20.04"
+                python-version: "3.6"
+            exclude:
+              # ubuntu-latest does not support python 3.6
+              - os: "ubuntu-latest"
+                python-version: "3.6"
     name: ${{ matrix.os }} with Python ${{ matrix.python-version }}
     defaults:
       run:
@@ -73,7 +81,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
 
       - name: "Install the package"
         shell: bash {0}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - '*'
+  schedule:
+    # Run tests every Sunday at 12am
+    - cron: '0 0 * * 0'
 
 concurrency:
   group: environment-${{ github.ref }}

--- a/pymare/__init__.py
+++ b/pymare/__init__.py
@@ -20,6 +20,7 @@ del _version
 
 def _py367_deprecation_warning():
     """Deprecation warnings message.
+
     Notes
     -----
     Adapted from NiMARE.
@@ -34,6 +35,7 @@ def _py367_deprecation_warning():
 
 def _python_deprecation_warnings():
     """Raise deprecation warnings.
+
     Notes
     -----
     Adapted from NiMARE.

--- a/pymare/__init__.py
+++ b/pymare/__init__.py
@@ -1,4 +1,7 @@
 """PyMARE: Python Meta-Analysis & Regression Engine."""
+import sys
+import warnings
+
 from .core import Dataset, meta_regression
 from .effectsize import OneSampleEffectSizeConverter, TwoSampleEffectSizeConverter
 
@@ -13,3 +16,32 @@ from . import _version
 
 __version__ = _version.get_versions()["version"]
 del _version
+
+
+def _py367_deprecation_warning():
+    """Deprecation warnings message.
+    Notes
+    -----
+    Adapted from NiMARE.
+    """
+    py36_warning = (
+        "Python 3.6 and 3.7 support is deprecated and will be removed in release 0.0.5 of PyMARE. "
+        "Consider switching to Python 3.8, 3.9."
+    )
+    warnings.filterwarnings("once", message=py36_warning)
+    warnings.warn(message=py36_warning, category=FutureWarning, stacklevel=3)
+
+
+def _python_deprecation_warnings():
+    """Raise deprecation warnings.
+    Notes
+    -----
+    Adapted from NiMARE.
+    """
+    if sys.version_info.major == 3 and (
+        sys.version_info.minor == 6 or sys.version_info.minor == 7
+    ):
+        _py367_deprecation_warning()
+
+
+_python_deprecation_warnings()

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,5 +97,7 @@ max-line-length = 99
 exclude=*build/,_version.py
 putty-ignore =
     */__init__.py : +F401
+per-file-ignores =
+    */__init__.py:D401
 ignore = E203,E402,E722,W503
 docstring-convention = numpy


### PR DESCRIPTION
Closes #113.

Changes proposed in this pull request:

- Add deprecation warnings when running NiMARE on Python 3.6 or 3.7.