### PR TITLE
[FIX] remove scipy version dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ python_requires = >= 3.8
 install_requires =
     numpy>=1.8.0
     pandas
-    scipy<1.13.0  # https://github.com/arviz-devs/arviz/issues/2336
+    scipy
     sympy
     wrapt
 packages = find:


### PR DESCRIPTION
the original issue has been resolved: https://github.com/arviz-devs/arviz/issues/2336
