### PR TITLE
[FIX] switch from np.math to math

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - "master"
-  pull_request_target:
+  pull_request:
     branches:
       - "*"
   schedule:
@@ -27,7 +27,7 @@ jobs:
     outputs:
       skip: ${{ steps.result_step.outputs.ci-skip }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - id: result_step
@@ -51,7 +51,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: "Set up python"
         uses: actions/setup-python@v2
         with:
@@ -74,7 +74,7 @@ jobs:
     name: Lint with flake8
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python environment
         uses: actions/setup-python@v2

--- a/pymare/results.py
+++ b/pymare/results.py
@@ -1,10 +1,10 @@
 """Tools for representing and manipulating meta-regression results."""
 
 import itertools
+import math
 from functools import lru_cache
 from inspect import getfullargspec
 from warnings import warn
-import math
 
 import numpy as np
 import pandas as pd

--- a/pymare/results.py
+++ b/pymare/results.py
@@ -4,6 +4,7 @@ import itertools
 from functools import lru_cache
 from inspect import getfullargspec
 from warnings import warn
+import math
 
 import numpy as np
 import pandas as pd
@@ -322,7 +323,7 @@ class MetaRegressionResults:
 
         # Calculate # of permutations and determine whether to use exact test
         if has_mods:
-            n_exact = np.math.factorial(n_obs)
+            n_exact = math.factorial(n_obs)
         else:
             n_exact = 2**n_obs
             if n_exact < n_perm:

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,8 @@ classifiers =
 [options]
 python_requires = >= 3.8
 install_requires =
-    numpy>=1.8.0
+    numpy>=1.8.0,<2.0; python_version == "3.9" and extra == 'stan'
+    numpy>=1.8.0; python_version != "3.9" or extra != 'stan'
     pandas
     scipy
     sympy


### PR DESCRIPTION
np.math is just a reference to the built in module math (and was removed in recent versions of numpy)